### PR TITLE
fix: mac-os uploaded artifacts

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -75,7 +75,7 @@ jobs:
         run: |
           (test -f dist/*.sha256sum && echo "EXISTS=true" >> $GITHUB_OUTPUT) || echo "EXISTS=false" >> $GITHUB_OUTPUT
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: steps.check_file.outputs.EXISTS == 'true'
         with:
           name: node${{ matrix.target-node }}-macos-arm64

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -35,7 +35,7 @@ jobs:
           ls -l dist
           (test -f dist/*.sha256sum && echo "EXISTS=true" >> $GITHUB_OUTPUT) || echo "EXISTS=false" >> $GITHUB_OUTPUT
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: steps.check_file.outputs.EXISTS == 'true'
         with:
           name: node${{ matrix.target-node }}-macos-x64

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -73,6 +73,7 @@ jobs:
       - name: Check if binary is compiled
         id: check_file
         run: |
+          ls -l dist
           (test -f dist/*.sha256sum && echo "EXISTS=true" >> $GITHUB_OUTPUT) || echo "EXISTS=false" >> $GITHUB_OUTPUT
 
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
Reason is because of [this](https://github.com/actions/download-artifact/tree/v4/?tab=readme-ov-file#breaking-changes):

> Downloading artifacts that were created from action/upload-artifact@v3 and below are not supported.