### PR TITLE
fix: use macos-13/14 runner

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   macos-x64:
-    runs-on: macos-13.0
+    runs-on: macos-13
 
     strategy:
       fail-fast: false
@@ -47,7 +47,7 @@ jobs:
           path: dist/*
 
   macos-arm64:
-    runs-on: macos-13.0
+    runs-on: macos-13
 
     strategy:
       fail-fast: false

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -82,16 +82,11 @@ jobs:
 
       - run: yarn install --ignore-engines
 
-      # # add missing distutils package to python 3.12
-      # - name: Install distutils
-      #   run: |
-      #     pip install setuptools
-      
-      - name: Ensure python has distutils
+      # add missing distutils package to python 3.12
+      - name: Install distutils
         run: |
-          python3 -m ensurepip
-          python3 -m pip install --upgrade pip
-          python3 -m pip install setuptools
+          # pip install setuptools
+          brew install python-setuptools
 
       - run: yarn start --node-range node${{ matrix.target-node }} --arch arm64 --output dist
         # uncomment the following lines to build x64

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -47,7 +47,7 @@ jobs:
           path: dist/*
 
   macos-arm64:
-    runs-on: macos-14 # starting from 14 it's ARM
+    runs-on: macos-13
 
     strategy:
       fail-fast: false
@@ -76,11 +76,11 @@ jobs:
           pip install setuptools
 
       - run: yarn start --node-range node${{ matrix.target-node }} --arch arm64 --output dist
-        # env:
-        #   CC: clang -arch arm64
-        #   CXX: clang++ -arch arm64
-        #   CC_host: clang
-        #   CXX_host: clang++
+        env:
+          CC: clang -arch arm64
+          CXX: clang++ -arch arm64
+          CC_host: clang
+          CXX_host: clang++
 
       - name: Check if binary is compiled
         id: check_file

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   macos-x64:
-    runs-on: macos-11.0
+    runs-on: macos-13.0
 
     strategy:
       fail-fast: false
@@ -47,7 +47,7 @@ jobs:
           path: dist/*
 
   macos-arm64:
-    runs-on: macos-11.0
+    runs-on: macos-13.0
 
     strategy:
       fail-fast: false

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -24,6 +24,13 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 18
+      
+      - name: Check arch is x64
+        run: |
+          if [[ $(uname -m) != "x86_64" ]]; then
+            echo "This job should run on x64 architecture"
+            exit 1
+          fi
 
       - run: yarn install --ignore-engines
 
@@ -47,7 +54,7 @@ jobs:
           path: dist/*
 
   macos-arm64:
-    runs-on: macos-13
+    runs-on: macos-14 # macos-14 is arm64: https://github.com/actions/runner-images#available-images
 
     strategy:
       fail-fast: false
@@ -66,21 +73,33 @@ jobs:
         with:
           node-version: 18
 
-      - run: uname -a
+      - name: Check arch is arm64
+        run: |
+          if [[ $(uname -m) != "arm64" ]]; then
+            echo "This job should run on arm64 architecture"
+            exit 1
+          fi
 
       - run: yarn install --ignore-engines
 
-      # add missing distutils package to python 3.12
-      - name: Install distutils
+      # # add missing distutils package to python 3.12
+      # - name: Install distutils
+      #   run: |
+      #     pip install setuptools
+      
+      - name: Ensure python has distutils
         run: |
-          pip install setuptools
+          python3 -m ensurepip
+          python3 -m pip install --upgrade pip
+          python3 -m pip install setuptools
 
       - run: yarn start --node-range node${{ matrix.target-node }} --arch arm64 --output dist
-        env:
-          CC: clang -arch arm64
-          CXX: clang++ -arch arm64
-          CC_host: clang
-          CXX_host: clang++
+        # uncomment the following lines to build x64
+        # env: 
+        #   CC: clang -arch arm64
+        #   CXX: clang++ -arch arm64
+        #   CC_host: clang
+        #   CXX_host: clang++
 
       - name: Check if binary is compiled
         id: check_file

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -84,11 +84,15 @@ jobs:
 
       - run: yarn install --ignore-engines
 
+
       # add missing distutils package to python 3.12
       - name: Install distutils
         run: |
-          # pip install setuptools
-          brew install python-setuptools
+          if [[ ${{ matrix.target-node }} == 18 ]]; then
+            pip install setuptools
+          else
+            brew install python-setuptools
+          fi
 
       - run: yarn start --node-range node${{ matrix.target-node }} --arch arm64 --output dist
         env:

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -74,6 +74,7 @@ jobs:
       - name: Install distutils
         run: |
           pip install setuptools
+          pip install distutils
 
       - run: yarn start --node-range node${{ matrix.target-node }} --arch arm64 --output dist
         # env:

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -89,6 +89,8 @@ jobs:
           brew install python-setuptools
 
       - run: yarn start --node-range node${{ matrix.target-node }} --arch arm64 --output dist
+        env:
+          MAKE_JOB_COUNT: 2 # prevent to run out of memory
         # uncomment the following lines to build x64
         # env: 
         #   CC: clang -arch arm64

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -47,7 +47,7 @@ jobs:
           path: dist/*
 
   macos-arm64:
-    runs-on: macos-13
+    runs-on: macos-14 # starting from 14 it's ARM
 
     strategy:
       fail-fast: false
@@ -66,6 +66,8 @@ jobs:
         with:
           node-version: 18
 
+      - run: uname -a
+
       - run: yarn install --ignore-engines
 
       # add missing distutils package to python 3.12
@@ -74,11 +76,11 @@ jobs:
           pip install setuptools
 
       - run: yarn start --node-range node${{ matrix.target-node }} --arch arm64 --output dist
-        env:
-          CC: clang -arch arm64
-          CXX: clang++ -arch arm64
-          CC_host: clang
-          CXX_host: clang++
+        # env:
+        #   CC: clang -arch arm64
+        #   CXX: clang++ -arch arm64
+        #   CC_host: clang
+        #   CXX_host: clang++
 
       - name: Check if binary is compiled
         id: check_file

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -74,7 +74,6 @@ jobs:
       - name: Install distutils
         run: |
           pip install setuptools
-          pip install distutils
 
       - run: yarn start --node-range node${{ matrix.target-node }} --arch arm64 --output dist
         # env:

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -40,6 +40,8 @@ jobs:
           pip install setuptools
 
       - run: yarn start --node-range node${{ matrix.target-node }} --output dist
+        env:
+          MAKE_JOB_COUNT: 2 # prevent to run out of memory
 
       - name: Check if binary is compiled, skip if download only
         id: check_file

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -56,7 +56,7 @@ jobs:
           path: dist/*
 
   macos-arm64:
-    runs-on: macos-14 # macos-14 is arm64: https://github.com/actions/runner-images#available-images
+    runs-on: macos-13 # macos-14 is arm64: https://github.com/actions/runner-images#available-images but not working
 
     strategy:
       fail-fast: false
@@ -75,10 +75,10 @@ jobs:
         with:
           node-version: 18
 
-      - name: Check arch is arm64
+      - name: Check arch is x64 # arm64
         run: |
-          if [[ $(uname -m) != "arm64" ]]; then
-            echo "This job should run on arm64 architecture"
+          if [[ $(uname -m) != "x86_64" ]]; then
+            echo "This job should run on x64 architecture"
             exit 1
           fi
 
@@ -94,11 +94,10 @@ jobs:
         env:
           MAKE_JOB_COUNT: 2 # prevent to run out of memory
         # uncomment the following lines to build x64
-        # env: 
-        #   CC: clang -arch arm64
-        #   CXX: clang++ -arch arm64
-        #   CC_host: clang
-        #   CXX_host: clang++
+          CC: clang -arch arm64
+          CXX: clang++ -arch arm64
+          CC_host: clang
+          CXX_host: clang++
 
       - name: Check if binary is compiled
         id: check_file


### PR DESCRIPTION
GH removed macos-11 runner as of June 2024: https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/.

Now there are macos-13 and macos-14 runners. The first is still x64 the latter is arm64 so we can build without cross compiling