### PR TITLE
fix: restore mac arm64 build

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -56,12 +56,12 @@ jobs:
           path: dist/*
 
   macos-arm64:
-    runs-on: macos-13 # macos-14 is arm64: https://github.com/actions/runner-images#available-images but not working
+    runs-on: macos-14 # macos-14 is arm64: https://github.com/actions/runner-images#available-images
 
     strategy:
       fail-fast: false
       matrix:
-        target-node: [16, 18, 20] # disabled 22 for now because of resource issues with GH actions
+        target-node: [18, 20, 22]
 
     steps:
       - uses: actions/checkout@v4
@@ -75,10 +75,10 @@ jobs:
         with:
           node-version: 20
 
-      - name: Check arch is x64 # arm64
+      - name: Check arch is arm64
         run: |
-          if [[ $(uname -m) != "x86_64" ]]; then
-            echo "This job should run on x64 architecture"
+          if [[ $(uname -m) != "arm64" ]]; then
+            echo "This job should run on arm64 architecture"
             exit 1
           fi
 
@@ -87,21 +87,20 @@ jobs:
 
       # add missing distutils package to python 3.12
       - name: Install distutils
+        run: brew install python-setuptools
+
+      # Remove unneeded stuff to free up build space (from Node https://github.com/nodejs/build/issues/3878)
+      - name: Cleanup before build
         run: |
-          if [[ ${{ matrix.target-node }} == 18 ]]; then
-            pip install setuptools
-          else
-            brew install python-setuptools
-          fi
+          sudo rm -rf /Users/runner/Library/Android/sdk
+          sudo rm -rf /Users/runner/Library/Developer/CoreSimulator/Caches
+          echo "::group::Free space after cleanup"
+          df -h
+          echo "::endgroup::"
 
       - run: yarn start --node-range node${{ matrix.target-node }} --arch arm64 --output dist
         env:
           MAKE_JOB_COUNT: 2 # prevent to run out of memory
-        # uncomment the following lines to build x64
-          CC: clang -arch arm64
-          CXX: clang++ -arch arm64
-          CC_host: clang
-          CXX_host: clang++
 
       - name: Check if binary is compiled
         id: check_file


### PR DESCRIPTION
Switch macos arm64 to native build using macos-14 runner
Free up a bunch of disk space on the macos-14 runner before building, the build seems to take up at least ~30GB at peak