### PR TITLE
refactor: replace `chalk` and `fs-extra`

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,5 @@
-import fs from 'fs-extra';
+import { unlinkSync } from 'fs';
+import { stat } from 'fs/promises';
 import path from 'path';
 import semver from 'semver';
 
@@ -37,7 +38,7 @@ async function download(
 
 async function exists(file: string) {
   try {
-    await fs.stat(file);
+    await stat(file);
     return true;
   } catch (error) {
     return false;
@@ -132,7 +133,7 @@ export async function need(opts: NeedOptions) {
       }
 
       log.info('Binary hash does NOT match. Re-fetching...');
-      fs.unlinkSync(fetched);
+      unlinkSync(fetched);
     }
   }
 
@@ -153,7 +154,7 @@ export async function need(opts: NeedOptions) {
         return fetched;
       }
 
-      fs.unlinkSync(fetched);
+      unlinkSync(fetched);
       throw wasReported('Binary hash does NOT match.');
     }
 

--- a/lib/log.ts
+++ b/lib/log.ts
@@ -2,7 +2,12 @@
 
 import Progress from 'progress';
 import assert from 'assert';
-import chalk from 'chalk';
+import picocolors from 'picocolors';
+import { WriteStream } from 'tty';
+
+// workaround until picocolors improves its color detection
+// https://github.com/alexeyraspopov/picocolors/issues/85
+const pc = picocolors.createColors(WriteStream.prototype.hasColors());
 
 class Log {
   debugMode = false;
@@ -29,7 +34,7 @@ class Log {
       return;
     }
 
-    console.log(`> ${chalk.green('[debug]')} ${text}`);
+    console.log(`> ${pc.green('[debug]')} ${text}`);
     this.lines(lines);
   }
 
@@ -39,13 +44,13 @@ class Log {
   }
 
   warn(text: string, lines?: string[] | string) {
-    console.log(`> ${chalk.blue('Warning')} ${text}`);
+    console.log(`> ${pc.blue('Warning')} ${text}`);
     this.lines(lines);
   }
 
   error(text: Error | string, lines?: string[] | string) {
     const message = text instanceof Error ? text.stack : text;
-    console.log(`> ${chalk.red('Error!')} ${message}`);
+    console.log(`> ${pc.red('Error!')} ${message}`);
     this.lines(lines);
   }
 

--- a/package.json
+++ b/package.json
@@ -18,10 +18,9 @@
     "patches/*"
   ],
   "dependencies": {
-    "chalk": "^4.1.2",
-    "fs-extra": "^9.1.0",
     "https-proxy-agent": "^5.0.0",
     "node-fetch": "^2.6.6",
+    "picocolors": "^1.1.0",
     "progress": "^2.0.3",
     "semver": "^7.3.5",
     "tar-fs": "^2.1.1",
@@ -29,8 +28,7 @@
   },
   "devDependencies": {
     "@release-it/conventional-changelog": "^7.0.2",
-    "@types/fs-extra": "^9.0.13",
-    "@types/node": "^14.17.32",
+    "@types/node": "^16.18.113",
     "@types/node-fetch": "^2.5.12",
     "@types/progress": "^2.0.5",
     "@types/semver": "^7.3.9",

--- a/scripts/test_patch.sh
+++ b/scripts/test_patch.sh
@@ -11,7 +11,7 @@ fi
 echo "Applying patches for $node_range"
 
 command="npm run applyPatches -- --node-range $node_range --quiet-extraction"
-output=$($command)
+output=$(NO_COLOR=1 $command)
 status=$?
 
 if [ $status -ne 0 ]; then

--- a/yarn.lock
+++ b/yarn.lock
@@ -260,13 +260,6 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz#db4ecfd499a9765ab24002c3b696d02e6d32a12c"
   integrity sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==
 
-"@types/fs-extra@^9.0.13":
-  version "9.0.13"
-  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.13.tgz#7594fbae04fe7f1918ce8b3d213f74ff44ac1f45"
-  integrity sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==
-  dependencies:
-    "@types/node" "*"
-
 "@types/http-cache-semantics@^4.0.1":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.2.tgz#abe102d06ccda1efdf0ed98c10ccf7f36a785a41"
@@ -295,10 +288,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.8.2.tgz#d76fb80d87d0d8abfe334fc6d292e83e5524efc4"
   integrity sha512-Vvycsc9FQdwhxE3y3DzeIxuEJbWGDsnrxvMADzTDF/lcdR9/K+AQIeAghTQsHtotg/q0j3WEOYS/jQgSdWue3w==
 
-"@types/node@^14.17.32":
-  version "14.18.63"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.63.tgz#1788fa8da838dbb5f9ea994b834278205db6ca2b"
-  integrity sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==
+"@types/node@^16.18.113":
+  version "16.18.113"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.113.tgz#fbe99013933c4997db5838d20497494a7e01f4ab"
+  integrity sha512-4jHxcEzSXpF1cBNxogs5FVbVSFSKo50sFCn7Xg7vmjJTbWFWgeuHW3QnoINlfmfG++MFR/q97RZE5RQXKeT+jg==
 
 "@types/normalize-package-data@^2.4.1":
   version "2.4.2"
@@ -652,11 +645,6 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
-at-least-node@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
-  integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
-
 available-typed-arrays@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
@@ -819,7 +807,7 @@ chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
+chalk@^4.0.0, chalk@^4.1.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -1844,16 +1832,6 @@ fs-extra@^8.1.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^9.1.0:
-  version "9.1.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
-  integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
-  dependencies:
-    at-least-node "^1.0.0"
-    graceful-fs "^4.2.0"
-    jsonfile "^6.0.1"
-    universalify "^2.0.0"
-
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -2690,15 +2668,6 @@ jsonfile@^4.0.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
-jsonfile@^6.0.1:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
-  integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
-  dependencies:
-    universalify "^2.0.0"
-  optionalDependencies:
-    graceful-fs "^4.1.6"
-
 jsonparse@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
@@ -3308,6 +3277,11 @@ path-type@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
+
+picocolors@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.0.tgz#5358b76a78cde483ba5cef6a9dc9671440b27d59"
+  integrity sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==
 
 picomatch@^2.3.1:
   version "2.3.1"
@@ -4175,11 +4149,6 @@ universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
-
-universalify@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
-  integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
 
 untildify@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
optimizes deps in here too :rocket:

`node-fetch` and `https-proxy-agent` should be easy to replace once node16 gets dropped

wanted to replace `yargs` with `minimist` (already used in `pkg`) but i'm not familiar with either of the apis

note: i had to use a fs api that was added in node 16 so i bumped `@types/node`