### PR TITLE
feat: add `riscv64` and `loong64` to known archs

### DIFF
--- a/lib/system.ts
+++ b/lib/system.ts
@@ -135,7 +135,7 @@ function getTargetArchs() {
 }
 
 function getKnownArchs() {
-  return ['x64', 'x86', 'armv7', 'arm64', 'ppc64', 's390x'];
+  return ['x64', 'x86', 'armv7', 'arm64', 'ppc64', 's390x', 'riscv64', 'loong64'];
 }
 
 export const hostAbi = getHostAbi();


### PR DESCRIPTION
These are two architecture that Node.js supports (however no official prebuilts; unofficial prebuilts are in https://unofficial-builds.nodejs.org/download/release/). Include them will at least allow us to build patch Node on those platforms. However to build in CI we probably need to update Dockerfile.linuxcross to at least GCC 13. I am not too sure if this affects compatibility.