### PR TITLE
[WIP] Add Node 24 support and attempt some Node 22 fixes

### DIFF
--- a/.github/workflows/build-alpine.yml
+++ b/.github/workflows/build-alpine.yml
@@ -5,21 +5,52 @@ on:
   workflow_call:
 
 jobs:
-  alpine:
+  alpine-x64:
     runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false
       matrix:
-        target-node: [16, 18, 20, 22]
-        target-arch: [x64, arm64]
-        include:
-          - target-arch: x64
-            target-triple: x86_64-linux-musl
-            host-arch: x86_64
-          - target-arch: arm64
-            target-triple: aarch64-linux-musl
-            host-arch: x86_64
+        target-node: [20, 22, 24]
+        target-arch: [x64]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build
+        uses: docker/build-push-action@v5
+        with:
+          build-args: |
+            PKG_FETCH_OPTION_a=${{ matrix.target-arch }}
+            PKG_FETCH_OPTION_n=node${{ matrix.target-node }}
+            PKG_FETCH_OPTION_p=alpine
+          context: .
+          file: ./Dockerfile.alpine
+          platforms: linux/amd64
+          outputs: type=local, dest=dist
+
+      - name: Check if binary is compiled, skip if download only
+        id: check_file
+        run: |
+          ls -l dist
+          (test -f dist/*.sha256sum && echo "EXISTS=true" >> $GITHUB_OUTPUT) || echo "EXISTS=false" >> $GITHUB_OUTPUT
+
+      - uses: actions/upload-artifact@v4
+        if: steps.check_file.outputs.EXISTS == 'true'
+        with:
+          name: node${{ matrix.target-node }}-alpine-${{ matrix.target-arch }}
+          path: dist/*
+
+  alpine-arm64:
+    runs-on: ubuntu-22.04-arm
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target-node: [20, 22, 24]
+        target-arch: [arm64]
 
     steps:
       - uses: actions/checkout@v4
@@ -31,14 +62,12 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           build-args: |
-            HOST_ARCH=${{ matrix.host-arch }}
-            TARGET_TRIPLE=${{ matrix.target-triple }}
             PKG_FETCH_OPTION_a=${{ matrix.target-arch }}
             PKG_FETCH_OPTION_n=node${{ matrix.target-node }}
             PKG_FETCH_OPTION_p=alpine
           context: .
           file: ./Dockerfile.alpine
-          platforms: linux/amd64
+          platforms: linux/arm64
           outputs: type=local, dest=dist
 
       - name: Check if binary is compiled, skip if download only

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target-node: [16, 18, 20, 22]
+        target-node: [20, 22, 24]
 
     steps:
       - uses: actions/checkout@v4
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target-node: [16, 18, 20, 22]
+        target-node: [20, 22, 24]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-linuxstatic.yml
+++ b/.github/workflows/build-linuxstatic.yml
@@ -5,13 +5,13 @@ on:
   workflow_call:
 
 jobs:
-  linuxstatic:
+  linuxstatic-legacy:
     runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false
       matrix:
-        target-node: [16, 18, 20, 22]
+        target-node: [20, 22]
         target-arch: [x64, arm64, armv7]
         include:
           - target-arch: x64
@@ -40,8 +40,84 @@ jobs:
             PKG_FETCH_OPTION_n=node${{ matrix.target-node }}
             PKG_FETCH_OPTION_p=linuxstatic
           context: .
-          file: ./Dockerfile.alpine
+          file: ./Dockerfile.alpine-muslcc
           platforms: linux/amd64
+          outputs: type=local, dest=dist
+
+      - name: Check if binary is compiled, skip if download only
+        id: check_file
+        run: |
+          ls -l dist
+          (test -f dist/*.sha256sum && echo "EXISTS=true" >> $GITHUB_OUTPUT) || echo "EXISTS=false" >> $GITHUB_OUTPUT
+
+      - uses: actions/upload-artifact@v4
+        if: steps.check_file.outputs.EXISTS == 'true'
+        with:
+          name: node${{ matrix.target-node }}-linuxstatic-${{ matrix.target-arch }}
+          path: dist/*
+
+  linuxstatic-x64:
+    runs-on: ubuntu-22.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target-node: [24]
+        target-arch: [x64]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build
+        uses: docker/build-push-action@v5
+        with:
+          build-args: |
+            PKG_FETCH_OPTION_a=${{ matrix.target-arch }}
+            PKG_FETCH_OPTION_n=node${{ matrix.target-node }}
+            PKG_FETCH_OPTION_p=linuxstatic
+          context: .
+          file: ./Dockerfile.alpine
+          outputs: type=local, dest=dist
+
+      - name: Check if binary is compiled, skip if download only
+        id: check_file
+        run: |
+          ls -l dist
+          (test -f dist/*.sha256sum && echo "EXISTS=true" >> $GITHUB_OUTPUT) || echo "EXISTS=false" >> $GITHUB_OUTPUT
+
+      - uses: actions/upload-artifact@v4
+        if: steps.check_file.outputs.EXISTS == 'true'
+        with:
+          name: node${{ matrix.target-node }}-linuxstatic-${{ matrix.target-arch }}
+          path: dist/*
+
+  linuxstatic-arm64:
+    runs-on: ubuntu-22.04-arm
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target-node: [24]
+        target-arch: [arm64]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build
+        uses: docker/build-push-action@v5
+        with:
+          build-args: |
+            PKG_FETCH_OPTION_a=${{ matrix.target-arch }}
+            PKG_FETCH_OPTION_n=node${{ matrix.target-node }}
+            PKG_FETCH_OPTION_p=linuxstatic
+          context: .
+          file: ./Dockerfile.alpine
           outputs: type=local, dest=dist
 
       - name: Check if binary is compiled, skip if download only

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -6,12 +6,12 @@ on:
 
 jobs:
   macos-x64:
-    runs-on: macos-13
+    runs-on: macos-14
 
     strategy:
       fail-fast: false
       matrix:
-        target-node: [16, 18, 20, 22]
+        target-node: [20, 22, 24]
 
     steps:
       - uses: actions/checkout@v4
@@ -24,13 +24,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-      
-      - name: Check arch is x64
-        run: |
-          if [[ $(uname -m) != "x86_64" ]]; then
-            echo "This job should run on x64 architecture"
-            exit 1
-          fi
 
       - run: yarn install --ignore-engines
 
@@ -39,7 +32,16 @@ jobs:
         run: |
           pip install setuptools
 
-      - run: yarn start --node-range node${{ matrix.target-node }} --output dist
+      # Remove unneeded stuff to free up build space (from Node https://github.com/nodejs/build/issues/3878)
+      - name: Cleanup before build
+        run: |
+          sudo rm -rf /Users/runner/Library/Android/sdk
+          sudo rm -rf /Users/runner/Library/Developer/CoreSimulator/Caches
+          echo "::group::Free space after cleanup"
+          df -h
+          echo "::endgroup::"
+
+      - run: yarn start --node-range node${{ matrix.target-node }} --arch x64 --output dist
         env:
           MAKE_JOB_COUNT: 2 # prevent to run out of memory
 
@@ -61,7 +63,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target-node: [18, 20, 22]
+        target-node: [20, 22, 24]
 
     steps:
       - uses: actions/checkout@v4
@@ -83,7 +85,6 @@ jobs:
           fi
 
       - run: yarn install --ignore-engines
-
 
       # add missing distutils package to python 3.12
       - name: Install distutils

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target-node: [16, 18, 20, 22]
+        target-node: [20, 22, 24]
         target-arch: [x64, arm64]
 
     steps:
@@ -21,6 +21,12 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          check-latest: true
 
       - run: yarn install --ignore-engines
 

--- a/.github/workflows/check-latest-node.yml
+++ b/.github/workflows/check-latest-node.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false # prevent test to stop if one fails
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [20, 22, 24]
 
     runs-on: ubuntu-latest
     steps:
@@ -36,7 +36,7 @@ jobs:
             # set the output variable to true
             echo "outdated=true" >> $GITHUB_OUTPUT
           fi
-      
+
       - name: Create new patch
         if: steps.compare.outputs.outdated == 'true'
         run: |
@@ -49,7 +49,7 @@ jobs:
           -H "Accept: application/vnd.github.v3+json" \
           https://api.github.com/repos/${{ github.repository }}/actions/workflows/patch-node.yml/dispatches \
           -d '{"ref":"main","inputs":{"nodeVersion":"${{ steps.compare.outputs.latest_version }}","patchFile":"${{ steps.compare.outputs.patch_version }}"}}'
-      
+
       # send a notification to the repository owner if the patch is outdated
       - name: Notify
         if: steps.compare.outputs.outdated == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false # prevent test to stop if one fails
       matrix:
-        node-version: [16, 18, 20, 22] # match patched node versions
+        node-version: [20, 22, 24] # match patched node versions
         os: [ubuntu-latest] # Skip macos-latest, windows-latest for now
 
     runs-on: ${{ matrix.os }}
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-          cache: "yarn"
+          cache: 'yarn'
 
       - name: Install deps
         run: yarn install --ignore-engines

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,24 +1,22 @@
-ARG HOST_ARCH=x86_64
-ARG TARGET_TRIPLE=aarch64-linux-musl
-
-FROM muslcc/$HOST_ARCH:$TARGET_TRIPLE AS build
+FROM alpine:3.22 AS build
 
 ARG PKG_FETCH_OPTION_a
 ARG PKG_FETCH_OPTION_n
 ARG PKG_FETCH_OPTION_p
 
-USER root:root
-
 WORKDIR /root/pkg-fetch/
 
-# HAXX upgrade alpine here because the muslcc image
-# is built on an old image and no newer version is available
-RUN sed -i -e 's/v3\.14/v3\.20/g' /etc/apk/repositories && \
-    apk update && \
-    apk add --upgrade apk-tools && \
-    apk upgrade --available
-
-RUN apk add --no-cache build-base git linux-headers npm python3 yarn
+RUN apk add --no-cache \
+    build-base \
+    git \
+    linux-headers \
+    npm \
+    python3 \
+    python3-dev \
+    yarn \
+    pkgconfig \
+    zlib-dev \
+    openssl-dev
 
 # https://gitlab.alpinelinux.org/alpine/aports/-/issues/8626
 ENV CFLAGS=-U_FORTIFY_SOURCE
@@ -26,18 +24,18 @@ ENV CFLAGS_host=-U_FORTIFY_SOURCE
 ENV CXXFLAGS=-U_FORTIFY_SOURCE
 ENV CXXFLAGS_host=-U_FORTIFY_SOURCE
 
-ENV CC=/bin/gcc
-ENV CXX=/bin/g++
-ENV AR=/bin/ar
-ENV NM=/bin/nm
-ENV READELF=/bin/readelf
-ENV STRIP=/bin/strip
+ENV CC=gcc
+ENV CXX=g++
+ENV AR=ar
+ENV NM=nm
+ENV READELF=readelf
+ENV STRIP=strip
 
-ENV CC_host=/usr/bin/gcc
-ENV CXX_host=/usr/bin/g++
-ENV AR_host=/usr/bin/ar
-ENV NM_host=/usr/bin/nm
-ENV READELF_host=/usr/bin/readelf
+ENV CC_host=gcc
+ENV CXX_host=g++
+ENV AR_host=ar
+ENV NM_host=nm
+ENV READELF_host=readelf
 
 COPY . ./
 

--- a/Dockerfile.alpine-muslcc
+++ b/Dockerfile.alpine-muslcc
@@ -1,0 +1,49 @@
+ARG HOST_ARCH=x86_64
+ARG TARGET_TRIPLE=aarch64-linux-musl
+
+FROM muslcc/$HOST_ARCH:$TARGET_TRIPLE AS build
+
+ARG PKG_FETCH_OPTION_a
+ARG PKG_FETCH_OPTION_n
+ARG PKG_FETCH_OPTION_p
+
+USER root:root
+
+WORKDIR /root/pkg-fetch/
+
+# HAXX upgrade alpine here because the muslcc image
+# is built on an old image and no newer version is available
+RUN sed -i -e 's/v3\.14/v3\.22/g' /etc/apk/repositories && \
+    apk update && \
+    apk add --upgrade apk-tools && \
+    apk upgrade --available
+
+RUN apk add --no-cache build-base git linux-headers npm python3 yarn
+
+# https://gitlab.alpinelinux.org/alpine/aports/-/issues/8626
+ENV CFLAGS=-U_FORTIFY_SOURCE
+ENV CFLAGS_host=-U_FORTIFY_SOURCE
+ENV CXXFLAGS=-U_FORTIFY_SOURCE
+ENV CXXFLAGS_host=-U_FORTIFY_SOURCE
+
+ENV CC=/bin/gcc
+ENV CXX=/bin/g++
+ENV AR=/bin/ar
+ENV NM=/bin/nm
+ENV READELF=/bin/readelf
+ENV STRIP=/bin/strip
+
+ENV CC_host=/usr/bin/gcc
+ENV CXX_host=/usr/bin/g++
+ENV AR_host=/usr/bin/ar
+ENV NM_host=/usr/bin/nm
+ENV READELF_host=/usr/bin/readelf
+
+COPY . ./
+
+RUN yarn install --ignore-engines
+
+RUN yarn start --arch $PKG_FETCH_OPTION_a --node-range $PKG_FETCH_OPTION_n --platform $PKG_FETCH_OPTION_p --output dist
+
+FROM scratch
+COPY --from=build /root/pkg-fetch/dist /

--- a/Dockerfile.linux
+++ b/Dockerfile.linux
@@ -14,7 +14,7 @@ RUN dnf upgrade -y
 
 # Install the necessary development tools and packages
 RUN dnf install -y \
-    gcc-toolset-10 glibc-headers kernel-headers \
+    gcc-toolset-12 glibc-headers kernel-headers \
     make patch python2 \
     python3.12
 
@@ -31,7 +31,7 @@ ARG PKG_FETCH_OPTION_n
 
 RUN yarn install --ignore-engines
 
-RUN source /opt/rh/gcc-toolset-10/enable && \
+RUN source /opt/rh/gcc-toolset-12/enable && \
     yarn start --node-range $PKG_FETCH_OPTION_n --output dist
 
 FROM scratch

--- a/Dockerfile.linuxcross
+++ b/Dockerfile.linuxcross
@@ -1,4 +1,4 @@
-FROM ubuntu:focal AS build
+FROM ubuntu:jammy AS build
 
 USER root:root
 WORKDIR /root/pkg-fetch/
@@ -13,22 +13,22 @@ RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
 
 RUN add-apt-repository ppa:ubuntu-toolchain-r/test -y && \
     apt-get update && \
-    apt-get install -y binutils g++-10 git make patch python3 python3-distutils
+    apt-get install -y binutils g++-12 git make patch python3 python3-distutils
 
 ARG TARGET_TOOLCHAIN_ARCH
 
 RUN [ `uname -m` = ${TARGET_TOOLCHAIN_ARCH} ] || \
-    apt-get install -y binutils-${TARGET_TOOLCHAIN_ARCH}-linux-gnu g++-10-${TARGET_TOOLCHAIN_ARCH}-linux-gnu
+    apt-get install -y binutils-${TARGET_TOOLCHAIN_ARCH}-linux-gnu g++-12-${TARGET_TOOLCHAIN_ARCH}-linux-gnu
 
-ENV CC=${TARGET_TOOLCHAIN_ARCH}-linux-gnu-gcc-10
-ENV CXX=${TARGET_TOOLCHAIN_ARCH}-linux-gnu-g++-10
+ENV CC=${TARGET_TOOLCHAIN_ARCH}-linux-gnu-gcc-12
+ENV CXX=${TARGET_TOOLCHAIN_ARCH}-linux-gnu-g++-12
 ENV AR=${TARGET_TOOLCHAIN_ARCH}-linux-gnu-ar
 ENV NM=${TARGET_TOOLCHAIN_ARCH}-linux-gnu-nm
 ENV RANLIB=${TARGET_TOOLCHAIN_ARCH}-linux-gnu-ranlib
 ENV READELF=${TARGET_TOOLCHAIN_ARCH}-linux-gnu-readelf
 ENV STRIP=${TARGET_TOOLCHAIN_ARCH}-linux-gnu-strip
-ENV CC_host=gcc-10
-ENV CXX_host=g++-10
+ENV CC_host=gcc-12
+ENV CXX_host=g++-12
 ENV AR_host=ar
 ENV NM_host=nm
 ENV RANLIB_host=ranlib

--- a/lib/build.ts
+++ b/lib/build.ts
@@ -69,7 +69,9 @@ function getConfigureArgs(major: number, targetPlatform: string, targetArch: str
   args.push('--without-npm');
 
   // Small ICU
+  if (hostPlatform !== 'win' || major < 24) {
   args.push('--with-intl=small-icu');
+  }
 
   // Workaround for nodejs/node#39313
   // All supported macOS versions have zlib as a system library
@@ -210,8 +212,16 @@ async function compileOnWindows(
     args.push('ltcg');
   }
 
+  // Node24 builds on Windows crash with small-icu at icudat codegen
+  // workaround for now is to enable full-icu
+  // TODO check with newer node/tooling/gh-image versions
+  if (major >= 24) {
+    args.push('full-icu');
+  }
+
   // Can't cross compile for arm64 with small-icu
   if (
+    major < 24 &&
     hostArch !== targetArch &&
     !config_flags.includes('--with-intl=full-icu')
   ) {

--- a/lib/build.ts
+++ b/lib/build.ts
@@ -70,7 +70,7 @@ function getConfigureArgs(major: number, targetPlatform: string, targetArch: str
 
   // Small ICU
   if (hostPlatform !== 'win' || major < 24) {
-  args.push('--with-intl=small-icu');
+    args.push('--with-intl=small-icu');
   }
 
   // Workaround for nodejs/node#39313
@@ -148,7 +148,8 @@ async function tarExtract(nodeVersion: string, suppressTarOutput: boolean) {
     strip: 1,
     map: (header) => {
       if (!suppressTarOutput) {
-        log.info(header.name);
+        // disabled for now - can't get cmdline flag to work with all builds
+        // log.info(header.name);
       }
       return header;
     },

--- a/patches/node.v22.19.0.cpp.patch
+++ b/patches/node.v22.19.0.cpp.patch
@@ -1,5 +1,5 @@
 diff --git node/common.gypi node/common.gypi
-index 7780ae106b..584d3756ee 100644
+index 7780ae106b4..584d3756ee5 100644
 --- node/common.gypi
 +++ node/common.gypi
 @@ -192,7 +192,7 @@
@@ -12,7 +12,7 @@ index 7780ae106b..584d3756ee 100644
            ],
          },
 diff --git node/deps/ngtcp2/nghttp3/lib/nghttp3_ringbuf.c node/deps/ngtcp2/nghttp3/lib/nghttp3_ringbuf.c
-index 7d3ab39bf8..67a48dee53 100644
+index 7d3ab39bf82..67a48dee53a 100644
 --- node/deps/ngtcp2/nghttp3/lib/nghttp3_ringbuf.c
 +++ node/deps/ngtcp2/nghttp3/lib/nghttp3_ringbuf.c
 @@ -34,10 +34,7 @@
@@ -28,7 +28,7 @@ index 7d3ab39bf8..67a48dee53 100644
  #else  /* !((defined(_MSC_VER) && !defined(__clang__) && (defined(_M_ARM) ||   \
            (defined(_M_ARM64) && _MSC_VER < 1941))) || defined(WIN32)) */
 diff --git node/deps/ngtcp2/ngtcp2/lib/ngtcp2_ringbuf.c node/deps/ngtcp2/ngtcp2/lib/ngtcp2_ringbuf.c
-index 353afca4d4..dea944aed5 100644
+index 353afca4d48..dea944aed5a 100644
 --- node/deps/ngtcp2/ngtcp2/lib/ngtcp2_ringbuf.c
 +++ node/deps/ngtcp2/ngtcp2/lib/ngtcp2_ringbuf.c
 @@ -33,10 +33,7 @@
@@ -44,7 +44,7 @@ index 353afca4d4..dea944aed5 100644
  #  else  /* !((defined(_MSC_VER) && !defined(__clang__) && (defined(_M_ARM) || \
              (defined(_M_ARM64) && _MSC_VER < 1941))) || defined(WIN32)) */
 diff --git node/deps/v8/include/v8-initialization.h node/deps/v8/include/v8-initialization.h
-index d3e35d6ec5..6e9bbe3849 100644
+index d3e35d6ec5f..6e9bbe38491 100644
 --- node/deps/v8/include/v8-initialization.h
 +++ node/deps/v8/include/v8-initialization.h
 @@ -89,6 +89,10 @@ class V8_EXPORT V8 {
@@ -59,7 +59,7 @@ index d3e35d6ec5..6e9bbe3849 100644
    static const char* GetVersion();
  
 diff --git node/deps/v8/src/api/api.cc node/deps/v8/src/api/api.cc
-index 2dd476dda3..8a51f25b57 100644
+index 2dd476dda34..8a51f25b572 100644
 --- node/deps/v8/src/api/api.cc
 +++ node/deps/v8/src/api/api.cc
 @@ -624,6 +624,28 @@ void V8::SetFlagsFromCommandLine(int* argc, char** argv, bool remove_flags) {
@@ -91,8 +91,22 @@ index 2dd476dda3..8a51f25b57 100644
  RegisteredExtension* RegisteredExtension::first_extension_ = nullptr;
  
  RegisteredExtension::RegisteredExtension(std::unique_ptr<Extension> extension)
+diff --git node/deps/v8/src/codegen/code-stub-assembler.h node/deps/v8/src/codegen/code-stub-assembler.h
+index b082bb8dc7b..285683ecdc8 100644
+--- node/deps/v8/src/codegen/code-stub-assembler.h
++++ node/deps/v8/src/codegen/code-stub-assembler.h
+@@ -286,7 +286,8 @@ enum class PrimitiveType { kBoolean, kNumber, kString, kSymbol };
+ 
+ // This is a check that always calls into the runtime if it aborts.
+ // This also exits silently when --hole-fuzzing is enabled.
+-#define CSA_HOLE_SECURITY_CHECK(csa, x) CSA_CHECK_WITH_ABORT(csa, x)
++#define CSA_HOLE_SECURITY_CHECK(csa, x) \
++  (csa)->Check([&]() -> TNode<BoolT> { return x; }, #x, "placeholder", 1)
+ 
+ #ifdef DEBUG
+ // CSA_DCHECK_ARGS generates an
 diff --git node/deps/v8/src/codegen/compiler.cc node/deps/v8/src/codegen/compiler.cc
-index 9048655363..ab81c326fc 100644
+index 9048655363c..ab81c326fc4 100644
 --- node/deps/v8/src/codegen/compiler.cc
 +++ node/deps/v8/src/codegen/compiler.cc
 @@ -3634,7 +3634,7 @@ MaybeHandle<SharedFunctionInfo> GetSharedFunctionInfoForScriptImpl(
@@ -105,7 +119,7 @@ index 9048655363..ab81c326fc 100644
      } else if (can_consume_code_cache) {
        compile_timer.set_consuming_code_cache();
 diff --git node/deps/v8/src/compiler/wasm-compiler.cc node/deps/v8/src/compiler/wasm-compiler.cc
-index 16f1f1470b..4bfeca49e6 100644
+index 16f1f1470b7..4bfeca49e64 100644
 --- node/deps/v8/src/compiler/wasm-compiler.cc
 +++ node/deps/v8/src/compiler/wasm-compiler.cc
 @@ -8613,12 +8613,13 @@ wasm::WasmCompilationResult CompileWasmImportCallWrapper(
@@ -149,7 +163,7 @@ index 16f1f1470b..4bfeca49e6 100644
      // Compile the wrapper
      if (job->ExecuteJob(isolate->counters()->runtime_call_stats()) ==
 diff --git node/deps/v8/src/heap/marking-visitor-inl.h node/deps/v8/src/heap/marking-visitor-inl.h
-index 39a5bbd22c..4b860f55d5 100644
+index 39a5bbd22c2..4b860f55d5e 100644
 --- node/deps/v8/src/heap/marking-visitor-inl.h
 +++ node/deps/v8/src/heap/marking-visitor-inl.h
 @@ -329,6 +329,13 @@ bool MarkingVisitorBase<ConcreteVisitor>::HasBytecodeArrayForFlushing(
@@ -167,7 +181,7 @@ index 39a5bbd22c..4b860f55d5 100644
  }
  
 diff --git node/deps/v8/src/objects/js-function.cc node/deps/v8/src/objects/js-function.cc
-index 529e283bbf..c997c53a18 100644
+index 529e283bbf0..c997c53a18c 100644
 --- node/deps/v8/src/objects/js-function.cc
 +++ node/deps/v8/src/objects/js-function.cc
 @@ -1308,6 +1308,10 @@ Handle<String> JSFunction::ToString(Handle<JSFunction> function) {
@@ -182,7 +196,7 @@ index 529e283bbf..c997c53a18 100644
            ClassPositions::cast(*maybe_class_positions);
        int start_position = class_positions->start();
 diff --git node/deps/v8/src/objects/objects.cc node/deps/v8/src/objects/objects.cc
-index 8e013c2544..7ac03149d8 100644
+index 8e013c2544e..7ac03149d86 100644
 --- node/deps/v8/src/objects/objects.cc
 +++ node/deps/v8/src/objects/objects.cc
 @@ -4263,7 +4263,12 @@ void Script::InitLineEndsInternal(IsolateT* isolate, Handle<Script> script) {
@@ -200,7 +214,7 @@ index 8e013c2544..7ac03149d8 100644
  }
  
 diff --git node/deps/v8/src/parsing/parsing.cc node/deps/v8/src/parsing/parsing.cc
-index f160b27ea4..748452ba45 100644
+index f160b27ea4d..748452ba451 100644
 --- node/deps/v8/src/parsing/parsing.cc
 +++ node/deps/v8/src/parsing/parsing.cc
 @@ -42,6 +42,7 @@ bool ParseProgram(ParseInfo* info, Handle<Script> script,
@@ -221,7 +235,7 @@ index f160b27ea4..748452ba45 100644
    std::unique_ptr<Utf16CharacterStream> stream(
        ScannerStream::For(isolate, source, shared_info->StartPosition(),
 diff --git node/deps/v8/src/snapshot/code-serializer.cc node/deps/v8/src/snapshot/code-serializer.cc
-index ec69ad5123..1894032344 100644
+index ec69ad51239..5bc92af5aad 100644
 --- node/deps/v8/src/snapshot/code-serializer.cc
 +++ node/deps/v8/src/snapshot/code-serializer.cc
 @@ -703,10 +703,6 @@ SerializedCodeSanityCheckResult SerializedCodeData::SanityCheck(
@@ -235,7 +249,7 @@ index ec69ad5123..1894032344 100644
    return SerializedCodeSanityCheckResult::kSuccess;
  }
  
-@@ -723,10 +719,6 @@ SerializedCodeSanityCheckResult SerializedCodeData::SanityCheckWithoutSource(
+@@ -723,13 +719,12 @@ SerializedCodeSanityCheckResult SerializedCodeData::SanityCheckWithoutSource(
    if (version_hash != Version::Hash()) {
      return SerializedCodeSanityCheckResult::kVersionMismatch;
    }
@@ -246,8 +260,28 @@ index ec69ad5123..1894032344 100644
    uint32_t ro_snapshot_checksum =
        GetHeaderValue(kReadOnlySnapshotChecksumOffset);
    if (ro_snapshot_checksum != expected_ro_snapshot_checksum) {
++    // for debugging snapshot checkum issues
++    // PrintF("[pkg] ReadOnlySnapshotChecksum mismatch: code=%08x built=%08x\n",
++    //  ro_snapshot_checksum, expected_ro_snapshot_checksum);
+     return SerializedCodeSanityCheckResult::kReadOnlySnapshotChecksumMismatch;
+   }
+   uint32_t payload_length = GetHeaderValue(kPayloadLengthOffset);
+diff --git node/deps/v8/src/snapshot/read-only-serializer.cc node/deps/v8/src/snapshot/read-only-serializer.cc
+index 29c69a782ef..4431cd14ac8 100644
+--- node/deps/v8/src/snapshot/read-only-serializer.cc
++++ node/deps/v8/src/snapshot/read-only-serializer.cc
+@@ -237,6 +237,9 @@ class EncodeRelocationsVisitor final : public ObjectVisitor {
+ 
+     // Encode:
+     ro::EncodedTagged encoded = Encode(isolate_, o.GetHeapObject());
++    #ifndef V8_COMPRESS_POINTERS
++    memset(segment_->contents.get() + slot_offset, 0, kTaggedSize);
++    #endif
+     memcpy(segment_->contents.get() + slot_offset, &encoded,
+            ro::EncodedTagged::kSize);
+ 
 diff --git node/lib/child_process.js node/lib/child_process.js
-index 655349b6fa..77092e0cd5 100644
+index 655349b6fa1..77092e0cd5b 100644
 --- node/lib/child_process.js
 +++ node/lib/child_process.js
 @@ -171,7 +171,7 @@ function fork(modulePath, args = [], options) {
@@ -261,7 +295,7 @@ index 655349b6fa..77092e0cd5 100644
  function _forkChild(fd, serializationMode) {
 diff --git node/lib/internal/bootstrap/pkg.js node/lib/internal/bootstrap/pkg.js
 new file mode 100644
-index 0000000000..a697294fdf
+index 00000000000..a697294fdfe
 --- /dev/null
 +++ node/lib/internal/bootstrap/pkg.js
 @@ -0,0 +1,49 @@
@@ -315,7 +349,7 @@ index 0000000000..a697294fdf
 +  }());
 +}());
 diff --git node/lib/internal/modules/cjs/loader.js node/lib/internal/modules/cjs/loader.js
-index a7d8fa1139..bffe5a8a53 100644
+index a7d8fa1139c..bffe5a8a538 100644
 --- node/lib/internal/modules/cjs/loader.js
 +++ node/lib/internal/modules/cjs/loader.js
 @@ -252,14 +252,18 @@ function stat(filename) {
@@ -340,7 +374,7 @@ index a7d8fa1139..bffe5a8a53 100644
    }
    return result;
 diff --git node/lib/internal/modules/package_json_reader.js node/lib/internal/modules/package_json_reader.js
-index fb669ea12e..6ad993581b 100644
+index fb669ea12ee..6ad993581bb 100644
 --- node/lib/internal/modules/package_json_reader.js
 +++ node/lib/internal/modules/package_json_reader.js
 @@ -108,17 +108,20 @@ const requiresJSONParse = (value) => (value !== undefined && (value[0] === '[' |
@@ -376,7 +410,7 @@ index fb669ea12e..6ad993581b 100644
      __proto__: null,
      ...result.data,
 diff --git node/lib/internal/process/pre_execution.js node/lib/internal/process/pre_execution.js
-index 98ed40e307..f9da878ea0 100644
+index 98ed40e3076..f9da878ea06 100644
 --- node/lib/internal/process/pre_execution.js
 +++ node/lib/internal/process/pre_execution.js
 @@ -50,7 +50,11 @@ const {
@@ -410,7 +444,7 @@ index 98ed40e307..f9da878ea0 100644
        Module: {
          _preloadModules,
 diff --git node/lib/vm.js node/lib/vm.js
-index ae71080620..b05638de75 100644
+index ae710806201..b05638de759 100644
 --- node/lib/vm.js
 +++ node/lib/vm.js
 @@ -98,6 +98,7 @@ class Script extends ContextifyScript {
@@ -432,7 +466,7 @@ index ae71080620..b05638de75 100644
        throw e; /* node-do-not-add-exception-line */
      }
 diff --git node/src/inspector_agent.cc node/src/inspector_agent.cc
-index aca49fddce..ddc54909ea 100644
+index aca49fddce0..ddc54909ea7 100644
 --- node/src/inspector_agent.cc
 +++ node/src/inspector_agent.cc
 @@ -832,11 +832,6 @@ bool Agent::Start(const std::string& path,
@@ -448,7 +482,7 @@ index aca49fddce..ddc54909ea 100644
      parent_env_->AddCleanupHook([](void* data) {
        Environment* env = static_cast<Environment*>(data);
 diff --git node/src/node.cc node/src/node.cc
-index 1b5e989e54..20f49ba2f2 100644
+index 1b5e989e545..20f49ba2f26 100644
 --- node/src/node.cc
 +++ node/src/node.cc
 @@ -404,6 +404,8 @@ MaybeLocal<Value> StartExecution(Environment* env, StartExecutionCallback cb) {
@@ -476,7 +510,7 @@ index 1b5e989e54..20f49ba2f2 100644
    }
  
 diff --git node/src/node_contextify.cc node/src/node_contextify.cc
-index 386102dfe7..fa452538bf 100644
+index 386102dfe7e..fa452538bf1 100644
 --- node/src/node_contextify.cc
 +++ node/src/node_contextify.cc
 @@ -86,6 +86,7 @@ using v8::Symbol;
@@ -551,7 +585,7 @@ index 386102dfe7..fa452538bf 100644
  }
  
 diff --git node/src/node_main.cc node/src/node_main.cc
-index f66099a557..4048f6bd93 100644
+index f66099a5570..4048f6bd937 100644
 --- node/src/node_main.cc
 +++ node/src/node_main.cc
 @@ -22,6 +22,8 @@
@@ -661,7 +695,7 @@ index f66099a557..4048f6bd93 100644
 +  return adjacent(c, nargv);
 +}
 diff --git node/src/node_options.cc node/src/node_options.cc
-index 249361e351..ef61e29dfb 100644
+index 249361e3519..ef61e29dfb3 100644
 --- node/src/node_options.cc
 +++ node/src/node_options.cc
 @@ -319,6 +319,7 @@ void Parse(
@@ -673,7 +707,7 @@ index 249361e351..ef61e29dfb 100644
    if (sea::IsSingleExecutable()) return;
  #endif
 diff --git node/tools/icu/icu-generic.gyp node/tools/icu/icu-generic.gyp
-index f007c65232..002a00a6ae 100644
+index f007c65232c..002a00a6aee 100644
 --- node/tools/icu/icu-generic.gyp
 +++ node/tools/icu/icu-generic.gyp
 @@ -52,7 +52,7 @@

--- a/patches/node.v24.7.0.cpp.patch
+++ b/patches/node.v24.7.0.cpp.patch
@@ -1,0 +1,855 @@
+diff --git node/common.gypi node/common.gypi
+index d4605a52de7..8e4e4fef1a4 100644
+--- node/common.gypi
++++ node/common.gypi
+@@ -192,7 +192,7 @@
+             ['clang==1', {
+               'lto': ' -flto ', # Clang
+             }, {
+-              'lto': ' -flto=4 -fuse-linker-plugin -ffat-lto-objects ', # GCC
++              'lto': ' -flto=4 -ffat-lto-objects ', # GCC
+             }],
+           ],
+         },
+diff --git node/deps/ngtcp2/nghttp3/lib/nghttp3_ringbuf.c node/deps/ngtcp2/nghttp3/lib/nghttp3_ringbuf.c
+index 7d3ab39bf82..67a48dee53a 100644
+--- node/deps/ngtcp2/nghttp3/lib/nghttp3_ringbuf.c
++++ node/deps/ngtcp2/nghttp3/lib/nghttp3_ringbuf.c
+@@ -34,10 +34,7 @@
+ #include "nghttp3_macro.h"
+ 
+ static int ispow2(size_t n) {
+-#if defined(_MSC_VER) && !defined(__clang__) &&                                \
+-  (defined(_M_ARM) || (defined(_M_ARM64) && _MSC_VER < 1941))
+-  return n && !(n & (n - 1));
+-#elif defined(WIN32)
++#if defined(WIN32)
+   return 1 == __popcnt((unsigned int)n);
+ #else  /* !((defined(_MSC_VER) && !defined(__clang__) && (defined(_M_ARM) ||   \
+           (defined(_M_ARM64) && _MSC_VER < 1941))) || defined(WIN32)) */
+diff --git node/deps/ngtcp2/ngtcp2/lib/ngtcp2_ringbuf.c node/deps/ngtcp2/ngtcp2/lib/ngtcp2_ringbuf.c
+index 353afca4d48..dea944aed5a 100644
+--- node/deps/ngtcp2/ngtcp2/lib/ngtcp2_ringbuf.c
++++ node/deps/ngtcp2/ngtcp2/lib/ngtcp2_ringbuf.c
+@@ -33,10 +33,7 @@
+ 
+ #ifndef NDEBUG
+ static int ispow2(size_t n) {
+-#  if defined(_MSC_VER) && !defined(__clang__) &&                              \
+-    (defined(_M_ARM) || (defined(_M_ARM64) && _MSC_VER < 1941))
+-  return n && !(n & (n - 1));
+-#  elif defined(WIN32)
++#if defined(WIN32)
+   return 1 == __popcnt((unsigned int)n);
+ #  else  /* !((defined(_MSC_VER) && !defined(__clang__) && (defined(_M_ARM) || \
+             (defined(_M_ARM64) && _MSC_VER < 1941))) || defined(WIN32)) */
+diff --git node/deps/v8/include/v8-initialization.h node/deps/v8/include/v8-initialization.h
+index 46a21a02cbc..fdb0edf42a0 100644
+--- node/deps/v8/include/v8-initialization.h
++++ node/deps/v8/include/v8-initialization.h
+@@ -98,6 +98,10 @@ class V8_EXPORT V8 {
+   static void SetFlagsFromCommandLine(int* argc, char** argv,
+                                       bool remove_flags);
+ 
++  static void EnableCompilationForSourcelessUse();
++  static void DisableCompilationForSourcelessUse();
++  static void FixSourcelessScript(Isolate* v8_isolate, Local<UnboundScript> script);
++
+   /** Get the version string. */
+   static const char* GetVersion();
+ 
+diff --git node/deps/v8/src/api/api.cc node/deps/v8/src/api/api.cc
+index ba759168aa9..f052c8b5a4c 100644
+--- node/deps/v8/src/api/api.cc
++++ node/deps/v8/src/api/api.cc
+@@ -443,6 +443,28 @@ void V8::SetFlagsFromCommandLine(int* argc, char** argv, bool remove_flags) {
+                                        HelpOptions(HelpOptions::kDontExit));
+ }
+ 
++bool save_lazy;
++bool save_predictable;
++
++void V8::EnableCompilationForSourcelessUse() {
++  save_lazy = i::v8_flags.lazy;
++  i::v8_flags.lazy = false;
++  save_predictable = i::v8_flags.predictable;
++  i::v8_flags.predictable = true;
++}
++
++void V8::DisableCompilationForSourcelessUse() {
++  i::v8_flags.lazy = save_lazy;
++  i::v8_flags.predictable = save_predictable;
++}
++
++void V8::FixSourcelessScript(Isolate* v8_isolate, Local<UnboundScript> unbound_script) {
++  auto isolate = reinterpret_cast<i::Isolate*>(v8_isolate);
++  auto function_info = i::Cast<i::SharedFunctionInfo>(Utils::OpenHandle(*unbound_script));
++  i::Handle<i::Script> script(i::Cast<i::Script>(function_info->script()), isolate);
++  script->SetSource(isolate, script,  isolate->factory()->empty_string());
++}
++
+ RegisteredExtension* RegisteredExtension::first_extension_ = nullptr;
+ 
+ RegisteredExtension::RegisteredExtension(std::unique_ptr<Extension> extension)
+diff --git node/deps/v8/src/codegen/compiler.cc node/deps/v8/src/codegen/compiler.cc
+index e31937f0429..fa8c37072f6 100644
+--- node/deps/v8/src/codegen/compiler.cc
++++ node/deps/v8/src/codegen/compiler.cc
+@@ -3945,7 +3945,7 @@ MaybeDirectHandle<SharedFunctionInfo> GetSharedFunctionInfoForScriptImpl(
+     maybe_script = lookup_result.script();
+     maybe_result = lookup_result.toplevel_sfi();
+     is_compiled_scope = lookup_result.is_compiled_scope();
+-    if (!maybe_result.is_null()) {
++    if (!maybe_result.is_null() && source->length()) {
+       compile_timer.set_hit_isolate_cache();
+     } else if (can_consume_code_cache) {
+       compile_timer.set_consuming_code_cache();
+diff --git node/deps/v8/src/codegen/define-code-stub-assembler-macros.inc node/deps/v8/src/codegen/define-code-stub-assembler-macros.inc
+index fb272f6afde..eb7c2375305 100644
+--- node/deps/v8/src/codegen/define-code-stub-assembler-macros.inc
++++ node/deps/v8/src/codegen/define-code-stub-assembler-macros.inc
+@@ -21,7 +21,7 @@
+ // This is a check that always calls into the runtime if it aborts.
+ // This also exits silently when --hole-fuzzing is enabled.
+ #define CSA_HOLE_SECURITY_CHECK(csa, x) \
+-  (csa)->Check([&]() -> TNode<BoolT> { return x; }, #x, __FILE__, __LINE__)
++  (csa)->Check([&]() -> TNode<BoolT> { return x; }, #x, "placeholder", 1)
+ 
+ #ifdef DEBUG
+ // CSA_DCHECK_ARGS generates an
+diff --git node/deps/v8/src/compiler/wasm-compiler.cc node/deps/v8/src/compiler/wasm-compiler.cc
+index 87a194b5c28..06270d0c6e1 100644
+--- node/deps/v8/src/compiler/wasm-compiler.cc
++++ node/deps/v8/src/compiler/wasm-compiler.cc
+@@ -1096,11 +1096,15 @@ wasm::WasmCompilationResult CompileWasmImportCallWrapper(
+                                  "wasm-to-js-%d-", static_cast<int>(kind));
+   PrintSignature(base::VectorOf(func_name, kMaxNameLen) + name_prefix_len, sig,
+                  '-');
++  wasm::WrapperCompilationInfo info;
++  info.code_kind = CodeKind::WASM_TO_JS_FUNCTION;
++  info.import_kind = kind;
++  info.expected_arity = expected_arity;
++  info.suspend = suspend;
+ 
+   auto result = Pipeline::GenerateCodeForWasmNativeStubFromTurboshaft(
+       sig,
+-      wasm::WrapperCompilationInfo{CodeKind::WASM_TO_JS_FUNCTION, kind,
+-                                   expected_arity, suspend},
++      info,
+       func_name, WasmStubAssemblerOptions(), nullptr);
+ 
+   if (V8_UNLIKELY(v8_flags.trace_wasm_compilation_times)) {
+diff --git node/deps/v8/src/heap/marking-visitor-inl.h node/deps/v8/src/heap/marking-visitor-inl.h
+index c38e02da079..6d6d7b33ed3 100644
+--- node/deps/v8/src/heap/marking-visitor-inl.h
++++ node/deps/v8/src/heap/marking-visitor-inl.h
+@@ -464,6 +464,13 @@ bool MarkingVisitorBase<ConcreteVisitor>::HasBytecodeArrayForFlushing(
+ template <typename ConcreteVisitor>
+ bool MarkingVisitorBase<ConcreteVisitor>::ShouldFlushCode(
+     Tagged<SharedFunctionInfo> sfi) const {
++  auto script_obj = sfi->script();
++  if (!IsUndefined(script_obj)) {
++    auto script = Cast<Script>(script_obj);
++    if (IsUndefined(script->source())) {
++      return false;
++    }
++  }
+   // This method is used both for flushing bytecode and baseline code.
+   // During last resort GCs and stress testing we consider all code old.
+   return IsOld(sfi) || V8_UNLIKELY(IsForceFlushingEnabled(code_flush_mode_));
+diff --git node/deps/v8/src/objects/js-function.cc node/deps/v8/src/objects/js-function.cc
+index 22df966c8ff..8c1835e0b67 100644
+--- node/deps/v8/src/objects/js-function.cc
++++ node/deps/v8/src/objects/js-function.cc
+@@ -1454,6 +1454,9 @@ DirectHandle<String> JSFunction::ToString(DirectHandle<JSFunction> function) {
+     DirectHandle<Object> maybe_class_positions = JSReceiver::GetDataProperty(
+         isolate, function, isolate->factory()->class_positions_symbol());
+     if (IsClassPositions(*maybe_class_positions)) {
++      if (IsUndefined(Cast<String>(Cast<Script>(shared_info->script())->source()))) {
++        return isolate->factory()->NewStringFromAsciiChecked("class {}");
++      }
+       Tagged<ClassPositions> class_positions =
+           Cast<ClassPositions>(*maybe_class_positions);
+       int start_position = class_positions->start();
+diff --git node/deps/v8/src/objects/objects.cc node/deps/v8/src/objects/objects.cc
+index 14013579bd5..1e9bc653e02 100644
+--- node/deps/v8/src/objects/objects.cc
++++ node/deps/v8/src/objects/objects.cc
+@@ -4347,7 +4347,11 @@ void Script::InitLineEndsInternal(IsolateT* isolate,
+ 
+ void Script::SetSource(Isolate* isolate, DirectHandle<Script> script,
+                        DirectHandle<String> source) {
+-  script->set_source(*source);
++  if (source->length() > 0) {
++    script->set_source(*source);
++  } else {
++    script->set_source(*isolate->factory()->undefined_value());
++  }
+   if (isolate->NeedsSourcePositions()) {
+     InitLineEnds(isolate, script);
+   } else if (script->line_ends() ==
+diff --git node/deps/v8/src/parsing/parsing.cc node/deps/v8/src/parsing/parsing.cc
+index 31758fdfede..483192fc350 100644
+--- node/deps/v8/src/parsing/parsing.cc
++++ node/deps/v8/src/parsing/parsing.cc
+@@ -42,6 +42,7 @@ bool ParseProgram(ParseInfo* info, DirectHandle<Script> script,
+   DCHECK(info->flags().is_toplevel());
+   DCHECK_NULL(info->literal());
+ 
++  if (IsUndefined(Cast<String>(script->source()))) return false;
+   VMState<PARSER> state(isolate);
+ 
+   // Create a character stream for the parser.
+@@ -75,6 +76,8 @@ bool ParseFunction(ParseInfo* info,
+ 
+   // Create a character stream for the parser.
+   DirectHandle<Script> script(Cast<Script>(shared_info->script()), isolate);
++  if (IsUndefined(Cast<String>(script->source()))) return false;
++
+   Handle<String> source(Cast<String>(script->source()), isolate);
+   uint32_t start_pos = shared_info->StartPosition();
+   uint32_t end_pos = shared_info->EndPosition();
+diff --git node/deps/v8/src/snapshot/code-serializer.cc node/deps/v8/src/snapshot/code-serializer.cc
+index 11ced93c085..1f4b5344153 100644
+--- node/deps/v8/src/snapshot/code-serializer.cc
++++ node/deps/v8/src/snapshot/code-serializer.cc
+@@ -771,10 +771,6 @@ SerializedCodeSanityCheckResult SerializedCodeData::SanityCheck(
+ 
+ SerializedCodeSanityCheckResult SerializedCodeData::SanityCheckJustSource(
+     uint32_t expected_source_hash) const {
+-  uint32_t source_hash = GetHeaderValue(kSourceHashOffset);
+-  if (source_hash != expected_source_hash) {
+-    return SerializedCodeSanityCheckResult::kSourceMismatch;
+-  }
+   return SerializedCodeSanityCheckResult::kSuccess;
+ }
+ 
+@@ -791,13 +787,12 @@ SerializedCodeSanityCheckResult SerializedCodeData::SanityCheckWithoutSource(
+   if (version_hash != Version::Hash()) {
+     return SerializedCodeSanityCheckResult::kVersionMismatch;
+   }
+-  uint32_t flags_hash = GetHeaderValue(kFlagHashOffset);
+-  if (flags_hash != FlagList::Hash()) {
+-    return SerializedCodeSanityCheckResult::kFlagsMismatch;
+-  }
+   uint32_t ro_snapshot_checksum =
+       GetHeaderValue(kReadOnlySnapshotChecksumOffset);
+   if (ro_snapshot_checksum != expected_ro_snapshot_checksum) {
++    // for debugging snapshot checkum issues
++    // PrintF("[pkg] ReadOnlySnapshotChecksum mismatch: code=%08x built=%08x\n",
++    //  ro_snapshot_checksum, expected_ro_snapshot_checksum);
+     return SerializedCodeSanityCheckResult::kReadOnlySnapshotChecksumMismatch;
+   }
+   uint32_t payload_length = GetHeaderValue(kPayloadLengthOffset);
+diff --git node/deps/v8/src/snapshot/read-only-serializer.cc node/deps/v8/src/snapshot/read-only-serializer.cc
+index fa60b3d07e0..a4f06a25c4b 100644
+--- node/deps/v8/src/snapshot/read-only-serializer.cc
++++ node/deps/v8/src/snapshot/read-only-serializer.cc
+@@ -12,6 +12,9 @@
+ #include "src/objects/slots.h"
+ #include "src/snapshot/read-only-serializer-deserializer.h"
+ 
++// for debugging readonly heap serialization
++// #define PKG_TRACE_READONLY_HEAP 1
++
+ namespace v8 {
+ namespace internal {
+ 
+@@ -160,6 +163,10 @@ ro::EncodedTagged Encode(Isolate* isolate, Tagged<HeapObject> o) {
+   uint32_t offset = static_cast<int>(chunk->Offset(o_address));
+   DCHECK(IsAligned(offset, kTaggedSize));
+ 
++  #ifdef PKG_TRACE_READONLY_HEAP
++  PrintF("      [PKGTRACE] encode tagged page_index=%d offset=%u offidx=%u\n",
++    index, offset, offset / kTaggedSize);
++  #endif
+   return ro::EncodedTagged(index, offset / kTaggedSize);
+ }
+ 
+@@ -247,6 +254,11 @@ class EncodeRelocationsVisitor final : public ObjectVisitor {
+ 
+     // Encode:
+     ro::EncodedTagged encoded = Encode(isolate_, o.GetHeapObject());
++
++    #ifndef V8_COMPRESS_POINTERS
++    memset(segment_->contents.get() + slot_offset, 0, kTaggedSize);
++    #endif
++
+     memcpy(segment_->contents.get() + slot_offset, &encoded,
+            ro::EncodedTagged::kSize);
+ 
+@@ -279,8 +291,18 @@ void ReadOnlySegmentForSerialization::EncodeTaggedSlots(Isolate* isolate) {
+   const Address segment_end = segment_start + segment_size;
+   ReadOnlyPageObjectIterator it(page, segment_start,
+                                 SkipFreeSpaceOrFiller::kNo);
++
++  #ifdef PKG_TRACE_READONLY_HEAP
++  uint32_t counter = 0;
++  #endif
++
+   for (Tagged<HeapObject> o = it.Next(); !o.is_null(); o = it.Next()) {
+     if (o.address() >= segment_end) break;
++    #ifdef PKG_TRACE_READONLY_HEAP
++    Tagged<Map> map = o->map(isolate);
++    PrintF("  [PKGTRACE] tag heapobj i=%d so=%zu s=%d t=%d\n",
++      counter++, o.address()-segment_start, o->Size(), map->instance_type());
++    #endif
+     VisitObject(isolate, o, &v);
+   }
+ }
+@@ -307,7 +329,14 @@ class ReadOnlyHeapImageSerializer {
+     DCHECK_EQ(sink_->Position(), 0);
+ 
+     ReadOnlySpace* ro_space = isolate_->read_only_heap()->read_only_space();
+-
++    #ifdef PKG_TRACE_READONLY_HEAP
++    #ifdef V8_COMPRESS_POINTERS
++    bool pce = true;
++    #else
++    bool pce = false;
++    #endif
++    PrintF("[PKGTRACE] BEGIN SERIALIZE READONLY ro_space=%p pce=%d\n", ro_space, pce);
++    #endif
+     // Allocate all pages first s.t. the deserializer can easily handle forward
+     // references (e.g.: an object on page i points at an object on page i+1).
+     for (const ReadOnlyPageMetadata* page : ro_space->pages()) {
+@@ -321,6 +350,10 @@ class ReadOnlyHeapImageSerializer {
+ 
+     EmitReadOnlyRootsTable();
+     sink_->Put(Bytecode::kFinalizeReadOnlySpace, "space end");
++
++    #ifdef PKG_TRACE_READONLY_HEAP
++    PrintF("[PKGTRACE] END SERIALIZE READONLY\n");
++    #endif
+   }
+ 
+   uint32_t IndexOf(const ReadOnlyPageMetadata* page) {
+@@ -339,6 +372,13 @@ class ReadOnlyHeapImageSerializer {
+     sink_->PutUint30(
+         static_cast<uint32_t>(page->HighWaterMark() - page->area_start()),
+         "area size in bytes");
++    #ifdef PKG_TRACE_READONLY_HEAP
++    PrintF("[PKGTRACE] emit allocate page area_ro_space_off=%zu area_start=%lx idx=%d size=%d \n",
++        ((uint8_t*)(page->area_start()))-((uint8_t*)(isolate_->read_only_heap()->read_only_space())),
++        page->area_start(),
++        IndexOf(page),
++        static_cast<uint32_t>(page->HighWaterMark() - page->area_start()));
++    #endif
+     if (V8_STATIC_ROOTS_BOOL) {
+       auto page_addr = page->ChunkAddress();
+       sink_->PutUint32(V8HeapCompressionScheme::CompressAny(page_addr),
+@@ -350,6 +390,9 @@ class ReadOnlyHeapImageSerializer {
+                      const std::vector<MemoryRegion>& unmapped_regions) {
+     Address pos = page->area_start();
+ 
++    #ifdef PKG_TRACE_READONLY_HEAP
++    PrintF("[PKGTRACE] serialize page addr=%lx\n");
++    #endif
+     // If this page contains unmapped regions split it into multiple segments.
+     for (auto r = unmapped_regions.begin(); r != unmapped_regions.end(); ++r) {
+       // Regions must be sorted and non-overlapping.
+@@ -372,9 +415,17 @@ class ReadOnlyHeapImageSerializer {
+     ReadOnlySegmentForSerialization segment(isolate_, page, pos, segment_size,
+                                             &pre_processor_);
+     EmitSegment(&segment);
++    #ifdef PKG_TRACE_READONLY_HEAP
++    PrintF("[PKGTRACE] last segment\n");
++    #endif
+   }
+ 
+   void EmitSegment(const ReadOnlySegmentForSerialization* segment) {
++    #ifdef PKG_TRACE_READONLY_HEAP
++    PrintF("  [PKGTRACE] segment segment_start=%lx page_index=%d offset=%zu size=%zu tagged_slots=%zu\n",
++        segment->segment_start, IndexOf(segment->page), segment->segment_offset,
++        segment->segment_size, segment->tagged_slots.size_in_bytes());
++    #endif
+     sink_->Put(Bytecode::kSegment, "segment begin");
+     sink_->PutUint30(IndexOf(segment->page), "page index");
+     sink_->PutUint30(static_cast<uint32_t>(segment->segment_offset),
+@@ -383,11 +434,29 @@ class ReadOnlyHeapImageSerializer {
+                      "segment byte size");
+     sink_->PutRaw(segment->contents.get(),
+                   static_cast<int>(segment->segment_size), "page");
++    #ifdef PKG_TRACE_READONLY_HEAP
++    PrintF("    [PKGTRACE] segment_contents: ");
++    const uint8_t* cdata = reinterpret_cast<const uint8_t*>(segment->contents.get());
++    for (size_t i = 0; i < segment->segment_size; i++) {
++        if (i%128==0) {PrintF("\n    [PKGTRACE]  ");}
++        PrintF("%02x", cdata[i]);
++    }
++    PrintF("\n");
++    #endif
+     if (!V8_STATIC_ROOTS_BOOL) {
+       sink_->Put(Bytecode::kRelocateSegment, "relocate segment");
+       sink_->PutRaw(segment->tagged_slots.data(),
+                     static_cast<int>(segment->tagged_slots.size_in_bytes()),
+                     "tagged_slots");
++      #ifdef PKG_TRACE_READONLY_HEAP
++      PrintF("    [PKGTRACE] tagged_slots: ");
++      const uint8_t* tdata = segment->tagged_slots.data();
++      for (size_t i = 0; i < segment->tagged_slots.size_in_bytes(); i++) {
++        if (i%128==0) {PrintF("\n    [PKGTRACE]  ");}
++          PrintF("%02x", tdata[i]);
++      }
++      PrintF("\n");
++      #endif
+     }
+   }
+ 
+@@ -395,11 +464,20 @@ class ReadOnlyHeapImageSerializer {
+     sink_->Put(Bytecode::kReadOnlyRootsTable, "read only roots table");
+     if (!V8_STATIC_ROOTS_BOOL) {
+       ReadOnlyRoots roots(isolate_);
++      #ifdef PKG_TRACE_READONLY_HEAP
++      PrintF("[PKGTRACE] readonly roots %lu\n", ReadOnlyRoots::kEntriesCount);
++      #endif
+       for (size_t i = 0; i < ReadOnlyRoots::kEntriesCount; i++) {
+         RootIndex rudi = static_cast<RootIndex>(i);
+         Tagged<HeapObject> rudolf = Cast<HeapObject>(roots.object_at(rudi));
+         ro::EncodedTagged encoded = Encode(isolate_, rudolf);
+         sink_->PutUint32(encoded.ToUint32(), "read only roots entry");
++        #ifdef PKG_TRACE_READONLY_HEAP
++        Tagged<Map> map = rudolf->map(isolate_);
++        InstanceType instance_type = map->instance_type();
++        PrintF("  [PKGTRACE] readonly root i=%zu e=%x s=%d t=%d\n",
++                i, encoded.ToUint32(), rudolf->Size(), instance_type);
++        #endif
+       }
+     }
+   }
+diff --git node/lib/child_process.js node/lib/child_process.js
+index 17c6b69c118..59f5e241afe 100644
+--- node/lib/child_process.js
++++ node/lib/child_process.js
+@@ -171,7 +171,7 @@ function fork(modulePath, args = [], options) {
+     throw new ERR_CHILD_PROCESS_IPC_REQUIRED('options.stdio');
+   }
+ 
+-  return spawn(options.execPath, args, options);
++  return module.exports.spawn(options.execPath, args, options);
+ }
+ 
+ function _forkChild(fd, serializationMode) {
+diff --git node/lib/internal/bootstrap/pkg.js node/lib/internal/bootstrap/pkg.js
+new file mode 100644
+index 00000000000..a697294fdfe
+--- /dev/null
++++ node/lib/internal/bootstrap/pkg.js
+@@ -0,0 +1,49 @@
++'use strict';
++
++const {
++  prepareWorkerThreadExecution,
++  prepareMainThreadExecution
++} = require('internal/process/pre_execution');
++
++if (internalBinding('worker').isMainThread) {
++  prepareMainThreadExecution(true);
++} else {
++  prepareWorkerThreadExecution();
++}
++
++(function () {
++  var __require__ = require;
++  var fs = __require__('fs');
++  var vm = __require__('vm');
++  function readPrelude (fd) {
++    var PAYLOAD_POSITION = '// PAYLOAD_POSITION //' | 0;
++    var PAYLOAD_SIZE = '// PAYLOAD_SIZE //' | 0;
++    var PRELUDE_POSITION = '// PRELUDE_POSITION //' | 0;
++    var PRELUDE_SIZE = '// PRELUDE_SIZE //' | 0;
++    if (!PRELUDE_POSITION) {
++      // no prelude - remove entrypoint from argv[1]
++      process.argv.splice(1, 1);
++      return { undoPatch: true };
++    }
++    var prelude = Buffer.alloc(PRELUDE_SIZE);
++    var read = fs.readSync(fd, prelude, 0, PRELUDE_SIZE, PRELUDE_POSITION);
++    if (read !== PRELUDE_SIZE) {
++      console.error('Pkg: Error reading from file.');
++      process.exit(1);
++    }
++    var s = new vm.Script(prelude, { filename: 'pkg/prelude/bootstrap.js' });
++    var fn = s.runInThisContext();
++    return fn(process, __require__,
++      console, fd, PAYLOAD_POSITION, PAYLOAD_SIZE);
++  }
++  (function () {
++    var fd = fs.openSync(process.execPath, 'r');
++    var result = readPrelude(fd);
++    if (result && result.undoPatch) {
++      var bindingFs = process.binding('fs');
++      fs.internalModuleStat = bindingFs.internalModuleStat;
++      fs.internalModuleReadJSON = bindingFs.internalModuleReadJSON;
++      fs.closeSync(fd);
++    }
++  }());
++}());
+diff --git node/lib/internal/modules/cjs/loader.js node/lib/internal/modules/cjs/loader.js
+index 222bb7fdd12..f9a6e23758f 100644
+--- node/lib/internal/modules/cjs/loader.js
++++ node/lib/internal/modules/cjs/loader.js
+@@ -254,12 +254,15 @@ function stat(filename) {
+   // Guard against internal bugs where a non-string filename is passed in by mistake.
+   assert(typeof filename === 'string');
+ 
++  const origFilename = filename;
+   filename = path.toNamespacedPath(filename);
+   if (statCache !== null) {
+     const result = statCache.get(filename);
+     if (result !== undefined) { return result; }
+   }
+-  const result = internalFsBinding.internalModuleStat(filename);
++  const fs = require('fs');
++  const result = fs.existsSync(origFilename) ?
++    (fs.statSync(origFilename).isDirectory() ? 1 : 0) : -1;
+   if (statCache !== null && result >= 0) {
+     // Only set cache when `internalModuleStat(filename)` succeeds.
+     statCache.set(filename, result);
+diff --git node/lib/internal/modules/package_json_reader.js node/lib/internal/modules/package_json_reader.js
+index 0dc15c9cd0b..58e35a6c972 100644
+--- node/lib/internal/modules/package_json_reader.js
++++ node/lib/internal/modules/package_json_reader.js
+@@ -108,17 +108,20 @@ const requiresJSONParse = (value) => (value !== undefined && (value[0] === '[' |
+  * @returns {PackageConfig}
+  */
+ function read(jsonPath, { base, specifier, isESM } = kEmptyObject) {
+-  // This function will be called by both CJS and ESM, so we need to make sure
+-  // non-null attributes are converted to strings.
+-  const parsed = modulesBinding.readPackageJSON(
+-    jsonPath,
+-    isESM,
+-    base == null ? undefined : `${base}`,
+-    specifier == null ? undefined : `${specifier}`,
+-  );
+-
+-  const result = deserializePackageJSON(jsonPath, parsed);
+-
++  const fs = require('fs');
++  let result;
++  if (fs.existsSync(jsonPath)) {
++    const json = JSONParse(fs.readFileSync(jsonPath, { encoding: "utf8" }).trim());
++    result = deserializePackageJSON(jsonPath, [
++      json['name'],
++      json['main'],
++      json['type'],
++      json['imports'],
++      json['exports'],
++    ]);
++  } else {
++    result = deserializePackageJSON(jsonPath, undefined);
++  }
+   return {
+     __proto__: null,
+     ...result.data,
+diff --git node/lib/internal/process/pre_execution.js node/lib/internal/process/pre_execution.js
+index c7f86098bdb..32eac7d2eee 100644
+--- node/lib/internal/process/pre_execution.js
++++ node/lib/internal/process/pre_execution.js
+@@ -42,7 +42,11 @@ const {
+   runDeserializeCallbacks,
+ } = require('internal/v8/startup_snapshot');
+ 
++let _alreadyPrepared = false;
++
+ function prepareMainThreadExecution(expandArgv1 = false, initializeModules = true) {
++  if (_alreadyPrepared === true) return;
++  _alreadyPrepared = true;
+   return prepareExecution({
+     expandArgv1,
+     initializeModules,
+@@ -241,7 +245,8 @@ function patchProcessObject(expandArgv1) {
+   let mainEntry;
+   // If requested, update process.argv[1] to replace whatever the user provided with the resolved absolute file path of
+   // the entry point.
+-  if (expandArgv1 && process.argv[1] && process.argv[1][0] !== '-') {
++  if (expandArgv1 && process.argv[1] && process.argv[1][0] !== '-' &&
++    process.argv[1] !== 'PKG_DUMMY_ENTRYPOINT') {
+     // Expand process.argv[1] into a full path.
+     const path = require('path');
+     try {
+@@ -678,6 +683,7 @@ function loadPreloadModules() {
+   // For user code, we preload modules if `-r` is passed
+   const preloadModules = getOptionValue('--require');
+   if (preloadModules && preloadModules.length > 0) {
++    assert(false, '--require is not supported');
+     const {
+       Module: {
+         _preloadModules,
+diff --git node/lib/vm.js node/lib/vm.js
+index ae710806201..b05638de759 100644
+--- node/lib/vm.js
++++ node/lib/vm.js
+@@ -98,6 +98,7 @@ class Script extends ContextifyScript {
+       produceCachedData = false,
+       importModuleDynamically,
+       [kParsingContext]: parsingContext,
++      sourceless = false,
+     } = options;
+ 
+     validateString(filename, 'options.filename');
+@@ -121,7 +122,8 @@ class Script extends ContextifyScript {
+             cachedData,
+             produceCachedData,
+             parsingContext,
+-            hostDefinedOptionId);
++            hostDefinedOptionId,
++            sourceless);
+     } catch (e) {
+       throw e; /* node-do-not-add-exception-line */
+     }
+diff --git node/src/inspector_agent.cc node/src/inspector_agent.cc
+index f62eb36b575..8ccc42dbd4f 100644
+--- node/src/inspector_agent.cc
++++ node/src/inspector_agent.cc
+@@ -833,11 +833,6 @@ bool Agent::Start(const std::string& path,
+                               StartIoThreadAsyncCallback));
+     uv_unref(reinterpret_cast<uv_handle_t*>(&start_io_thread_async));
+     start_io_thread_async.data = this;
+-    if (parent_env_->should_start_debug_signal_handler()) {
+-      // Ignore failure, SIGUSR1 won't work, but that should not block node
+-      // start.
+-      StartDebugSignalHandler();
+-    }
+ 
+     parent_env_->AddCleanupHook([](void* data) {
+       Environment* env = static_cast<Environment*>(data);
+diff --git node/src/node.cc node/src/node.cc
+index 79c9dff69cf..a0ff7aabbc3 100644
+--- node/src/node.cc
++++ node/src/node.cc
+@@ -355,6 +355,8 @@ MaybeLocal<Value> StartExecution(Environment* env, StartExecutionCallback cb) {
+     return env->RunSnapshotDeserializeMain();
+   }
+ 
++  StartExecution(env, "internal/bootstrap/pkg");
++
+   if (env->worker_context() != nullptr) {
+     return StartExecution(env, "internal/main/worker_thread");
+   }
+@@ -579,14 +581,6 @@ static void PlatformInit(ProcessInitializationFlags::Flags flags) {
+   }
+ 
+   if (!(flags & ProcessInitializationFlags::kNoDefaultSignalHandling)) {
+-#if HAVE_INSPECTOR
+-    sigset_t sigmask;
+-    sigemptyset(&sigmask);
+-    sigaddset(&sigmask, SIGUSR1);
+-    const int err = pthread_sigmask(SIG_SETMASK, &sigmask, nullptr);
+-    CHECK_EQ(err, 0);
+-#endif  // HAVE_INSPECTOR
+-
+     ResetSignalHandlers();
+   }
+ 
+diff --git node/src/node_contextify.cc node/src/node_contextify.cc
+index ef4bc008540..ad9dec0723e 100644
+--- node/src/node_contextify.cc
++++ node/src/node_contextify.cc
+@@ -87,6 +87,7 @@ using v8::Symbol;
+ using v8::Uint32;
+ using v8::UnboundScript;
+ using v8::Value;
++using v8::V8;
+ 
+ // The vm module executes code in a sandboxed environment with a different
+ // global object than the rest of the code. This is achieved by applying
+@@ -994,13 +995,13 @@ void ContextifyScript::New(const FunctionCallbackInfo<Value>& args) {
+   Local<ArrayBufferView> cached_data_buf;
+   bool produce_cached_data = false;
+   Local<Context> parsing_context = context;
+-
++  bool sourceless = false;
+   Local<Symbol> id_symbol;
+   if (argc > 2) {
+     // new ContextifyScript(code, filename, lineOffset, columnOffset,
+     //                      cachedData, produceCachedData, parsingContext,
+-    //                      hostDefinedOptionId)
+-    CHECK_EQ(argc, 8);
++    //                      hostDefinedOptionId, sourceless)
++    CHECK_GE(argc, 8);
+     CHECK(args[2]->IsNumber());
+     line_offset = args[2].As<Int32>()->Value();
+     CHECK(args[3]->IsNumber());
+@@ -1021,6 +1022,11 @@ void ContextifyScript::New(const FunctionCallbackInfo<Value>& args) {
+     }
+     CHECK(args[7]->IsSymbol());
+     id_symbol = args[7].As<Symbol>();
++
++    if (argc > 8) {
++      CHECK(args[8]->IsBoolean());
++        sourceless = args[8]->IsTrue();
++    }
+   }
+ 
+   ContextifyScript* contextify_script = New(env, args.This());
+@@ -1067,6 +1073,10 @@ void ContextifyScript::New(const FunctionCallbackInfo<Value>& args) {
+   ShouldNotAbortOnUncaughtScope no_abort_scope(env);
+   Context::Scope scope(parsing_context);
+ 
++  if (sourceless && produce_cached_data) {
++    V8::EnableCompilationForSourcelessUse();
++  }
++
+   MaybeLocal<UnboundScript> maybe_v8_script =
+       ScriptCompiler::CompileUnboundScript(isolate, &source, compile_options);
+ 
+@@ -1081,6 +1091,12 @@ void ContextifyScript::New(const FunctionCallbackInfo<Value>& args) {
+     return;
+   }
+ 
++  if (sourceless && compile_options == ScriptCompiler::kConsumeCodeCache) {
++    if (!source.GetCachedData()->rejected) {
++      V8::FixSourcelessScript(env->isolate(), v8_script);
++    }
++  }
++
+   contextify_script->set_unbound_script(v8_script);
+ 
+   std::unique_ptr<ScriptCompiler::CachedData> new_cached_data;
+@@ -1118,6 +1134,10 @@ void ContextifyScript::New(const FunctionCallbackInfo<Value>& args) {
+           .IsNothing())
+     return;
+ 
++  if (sourceless && produce_cached_data) {
++    V8::DisableCompilationForSourcelessUse();
++  }
++
+   TRACE_EVENT_END0(TRACING_CATEGORY_NODE2(vm, script), "ContextifyScript::New");
+ }
+ 
+diff --git node/src/node_main.cc node/src/node_main.cc
+index 3295121b87a..bfe838b8c17 100644
+--- node/src/node_main.cc
++++ node/src/node_main.cc
+@@ -22,6 +22,8 @@
+ #include "node.h"
+ #include <cstdio>
+ 
++int reorder(int argc, char** argv);
++
+ #ifdef _WIN32
+ #include <windows.h>
+ #include <VersionHelpers.h>
+@@ -88,12 +90,95 @@ int wmain(int argc, wchar_t* wargv[]) {
+   }
+   argv[argc] = nullptr;
+   // Now that conversion is done, we can finally start.
+-  return node::Start(argc, argv);
++  return reorder(argc, argv);
+ }
+ #else
+ // UNIX
+ 
+ int main(int argc, char* argv[]) {
++  return reorder(argc, argv);
++}
++#endif
++
++#include <string.h>
++
++int strlen2 (char* s) {
++  int len = 0;
++  while (*s) {
++    len += 1;
++    s += 1;
++  }
++  return len;
++}
++
++bool should_set_dummy() {
++#ifdef _WIN32
++  #define MAX_ENV_LENGTH 32767
++  wchar_t execpath_env[MAX_ENV_LENGTH];
++  DWORD result = GetEnvironmentVariableW(L"PKG_EXECPATH", execpath_env, MAX_ENV_LENGTH);
++  if (result == 0 && GetLastError() != ERROR_SUCCESS) return true;
++  return wcscmp(execpath_env, L"PKG_INVOKE_NODEJS") != 0;
++#else
++  const char* execpath_env = getenv("PKG_EXECPATH");
++  if (!execpath_env) return true;
++  return strcmp(execpath_env, "PKG_INVOKE_NODEJS") != 0;
++#endif
++}
++
++// for uv_setup_args
++int adjacent(int argc, char** argv) {
++  size_t size = 0;
++  for (int i = 0; i < argc; i++) {
++    size += strlen(argv[i]) + 1;
++  }
++  char* args = new char[size];
++  size_t pos = 0;
++  for (int i = 0; i < argc; i++) {
++    memcpy(&args[pos], argv[i], strlen(argv[i]) + 1);
++    argv[i] = &args[pos];
++    pos += strlen(argv[i]) + 1;
++  }
+   return node::Start(argc, argv);
+ }
++
++volatile char* BAKERY = (volatile char*) "\0// BAKERY // BAKERY " \
++  "// BAKERY // BAKERY // BAKERY // BAKERY // BAKERY // BAKERY " \
++  "// BAKERY // BAKERY // BAKERY // BAKERY // BAKERY // BAKERY " \
++  "// BAKERY // BAKERY // BAKERY // BAKERY // BAKERY // BAKERY ";
++
++#ifdef __clang__
++__attribute__((optnone))
++#elif defined(__GNUC__)
++__attribute__((optimize(0)))
+ #endif
++
++int load_baked(char** nargv) {
++  int c = 1;
++
++  char* bakery = (char*) BAKERY;
++  while (true) {
++    size_t width = strlen2(bakery);
++    if (width == 0) break;
++    nargv[c++] = bakery;
++    bakery += width + 1;
++  }
++
++  return c;
++}
++
++int reorder(int argc, char** argv) {
++  char** nargv = new char*[argc + 64];
++
++  nargv[0] = argv[0];
++  int c = load_baked(nargv);
++
++  if (should_set_dummy()) {
++    nargv[c++] = (char*) "PKG_DUMMY_ENTRYPOINT";
++  }
++
++  for (int i = 1; i < argc; i++) {
++    nargv[c++] = argv[i];
++  }
++
++  return adjacent(c, nargv);
++}
+diff --git node/src/node_options.cc node/src/node_options.cc
+index 159954cb694..96eea09916e 100644
+--- node/src/node_options.cc
++++ node/src/node_options.cc
+@@ -422,6 +422,7 @@ void Parse(
+ // TODO(addaleax): Make that unnecessary.
+ 
+ DebugOptionsParser::DebugOptionsParser() {
++  return;
+ #ifndef DISABLE_SINGLE_EXECUTABLE_APPLICATION
+   if (sea::IsSingleExecutable()) return;
+ #endif
+diff --git node/tools/icu/icu-generic.gyp node/tools/icu/icu-generic.gyp
+index f007c65232c..002a00a6aee 100644
+--- node/tools/icu/icu-generic.gyp
++++ node/tools/icu/icu-generic.gyp
+@@ -52,7 +52,7 @@
+         'conditions': [
+           [ 'os_posix == 1 and OS != "mac" and OS != "ios"', {
+             'cflags': [ '-Wno-deprecated-declarations', '-Wno-strict-aliasing' ],
+-            'cflags_cc': [ '-frtti' ],
++            'cflags_cc': [ '-frtti', '-fno-lto' ],
+             'cflags_cc!': [ '-fno-rtti' ],
+           }],
+           [ 'OS == "mac" or OS == "ios"', {

--- a/patches/patches.json
+++ b/patches/patches.json
@@ -1,4 +1,5 @@
 {
+  "v24.7.0": ["node.v24.7.0.cpp.patch"],
   "v22.19.0": ["node.v22.19.0.cpp.patch"],
   "v20.19.4": ["node.v20.19.4.cpp.patch"],
   "v18.20.8": ["node.v18.20.8.cpp.patch"],


### PR DESCRIPTION
This PR adds Node24 support

**Node/V8 changes:**
- Move to new V8 syntax for some constructs (e.g. Cast<>)
- Tracked down two issues which caused the read-only snapshot to different across platforms:
  - in `read-only-serializer:258` the "live" pointer gets overwritten by the encoded slot (EncodedTagged)
    if V8_COMPRESS_POINTERS is not enabled, the EncodedTagged is 4 bytes, but the live pointer is 8 bytes
   the memcpy() only copies the EncodeTagged leaving 4bytes of "garbage" (=previous upper pointer half) which is semi-random per run - fixed this to clear the whole value first
  - the CSA_HOLE_SECURITY_CHECK macro somehow leaves a string with a platform-dependent filename in the readonly heap as a constant, replaced that with "placeholder"
 - add PKG_TRACE_READONLY_HEAP blocks for debugging further snapshot issues

Those fixes partially fix the sourceless cross-build issues introduced in Node 22 - For my test builds linux/linuxstatic/alpine/win on x64 are now compatible again. The heap contents on macos builds and other arm64 is wildly different, not sure why. I don't think this kind of compatibility is a goal for the V8 snapshot implementation in general. (This affects Node SEA as well, but SEA always has the source to fall back onto, which incurs a small performance hit)

**Build Changes:**

- Update linux/linuxcross build to use gcc 12 (required for Node 24)
- For aloine/linuxstatic: Node 24 doesn't build on the muslcc image used previously, the image is unmaintained (although the toolchain builder isn't, we could build our own image)
- Moved alpine/linuxstatic to native Alpine x64/arm64 toolchains, which seems to work quite well
- Some minor upgrades to the Windows build, but had to enable `full-icu` for now because the ICU code gen step crashes with `small-icu` on the GH action build runners (not on my Windows test machine though)
- Moved the macos build to macos 14 which is now required for Node 24 - x64 is now cross-built from arm64 because GH doesn't offer free macos14 x64 build workers

**Notes:**
- Needs more  testing, I did some basic testing for x64 builds  as well as macos/arm64
- I added a backport of the snapshot-determinism fixes to the latest Node 22 patch

