### PR TITLE
build: use jammy to build linux.cross

### DIFF
--- a/Dockerfile.linuxcross
+++ b/Dockerfile.linuxcross
@@ -1,4 +1,4 @@
-FROM ubuntu:noble AS build
+FROM ubuntu:jammy AS build
 
 USER root:root
 WORKDIR /root/pkg-fetch/
@@ -11,22 +11,22 @@ RUN apt-get install -y curl software-properties-common ca-certificates gnupg
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
     apt-get install -y nodejs
 
-RUN apt-get install -y binutils g++ git make patch python3 python3-setuptools
+RUN apt-get install -y binutils g++-12 git make patch python3 python3-setuptools
 
 ARG TARGET_TOOLCHAIN_ARCH
 
 RUN [ `uname -m` = ${TARGET_TOOLCHAIN_ARCH} ] || \
-    apt-get install -y binutils-${TARGET_TOOLCHAIN_ARCH}-linux-gnu g++-${TARGET_TOOLCHAIN_ARCH}-linux-gnu
+    apt-get install -y binutils-${TARGET_TOOLCHAIN_ARCH}-linux-gnu g++-12-${TARGET_TOOLCHAIN_ARCH}-linux-gnu
 
-ENV CC=${TARGET_TOOLCHAIN_ARCH}-linux-gnu-gcc
-ENV CXX=${TARGET_TOOLCHAIN_ARCH}-linux-gnu-g++
+ENV CC=${TARGET_TOOLCHAIN_ARCH}-linux-gnu-gcc-12
+ENV CXX=${TARGET_TOOLCHAIN_ARCH}-linux-gnu-g++-12
 ENV AR=${TARGET_TOOLCHAIN_ARCH}-linux-gnu-ar
 ENV NM=${TARGET_TOOLCHAIN_ARCH}-linux-gnu-nm
 ENV RANLIB=${TARGET_TOOLCHAIN_ARCH}-linux-gnu-ranlib
 ENV READELF=${TARGET_TOOLCHAIN_ARCH}-linux-gnu-readelf
 ENV STRIP=${TARGET_TOOLCHAIN_ARCH}-linux-gnu-strip
-ENV CC_host=gcc
-ENV CXX_host=g++
+ENV CC_host=gcc-12
+ENV CXX_host=g++-12
 ENV AR_host=ar
 ENV NM_host=nm
 ENV RANLIB_host=ranlib


### PR DESCRIPTION
Use Ubuntu Jammy for cross-building Linux ARM64 binaries using GCC 12

Fixes https://github.com/yao-pkg/pkg-fetch/issues/122
