### PR TITLE
chore: migrate to es2022 target

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2022",
     "module": "commonjs",
     "allowJs": true,
     "declaration": true,


### PR DESCRIPTION
es5 is extremely unreadable and hard to debug.