### PR TITLE
fix: remove incorrect --without-intl for Windows arm64 cross-compilation

### DIFF
--- a/lib/build.ts
+++ b/lib/build.ts
@@ -220,15 +220,6 @@ async function compileOnWindows(
     args.push('full-icu');
   }
 
-  // Can't cross compile for arm64 with small-icu
-  if (
-    major < 24 &&
-    hostArch !== targetArch &&
-    !config_flags.includes('--with-intl=full-icu')
-  ) {
-    config_flags.push('--without-intl');
-  }
-
   await spawn('cmd', args, {
     cwd: nodePath,
     env: { ...process.env, config_flags: config_flags.join(' ') },


### PR DESCRIPTION
The `--without-intl` guard in `compileOnWindows()` was intended to handle a real problem on Linux/macOS hosts: when cross-compiling for a different arch, ICU's build system compiles its own host tools for the target architecture, meaning they can't run on the build machine and the build fails. Disabling ICU entirely was the workaround for that case.

However, `compileOnWindows()` only ever runs on Windows hosts, where MSVC's ARM64 cross-compilation toolchain handles this correctly — host tools are built as x64, target code is built as arm64. `--with-intl=small-icu` works fine for Windows x64 → arm64 cross-compilation on Node < 24. (Node >= 24 already uses `full-icu` via the existing workaround above for the separate genccode/ClangCL issue.)

The practical consequence of this bug: pkg-fetch was producing `win-arm64` Node < 24 base binaries without any ICU support. When pkg bundled an app using one of these binaries, the V8 bytecode version hash wouldn't match the fabricator binary (which had ICU enabled), causing a silent `process.exit(4)` at startup on all Windows ARM64 machines. This was the root cause of pnpm/pnpm#9207.

PR #150 worked around this by switching the arm64 CI job to a native `windows-11-arm` runner (where `hostArch === targetArch`, so the guard never fired). This PR removes the guard itself, which was the underlying bug.

Closes #152
Related: pnpm/pnpm#9207