### PR TITLE
chore: bump all GitHub Actions to latest majors + replace softprops

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -125,24 +125,44 @@ jobs:
           TAG: ${{ env.use_release_tag }}
           DRAFT: ${{ env.create_draft }}
           BODY: ${{ env.sha_summary }}
+        # Replaces a SHA-pinned `softprops/action-gh-release@d4e8205` call
+        # that ran with `generate_release_notes: true` + `append_body: true`.
+        # We must preserve those semantics exactly:
+        #   - On UPDATE (release already exists for the tag): softprops with
+        #     `append_body: true` keeps the existing release body and appends
+        #     the new `body`. `generate_release_notes` is silently ignored
+        #     by the GitHub PATCH /releases API on update, so softprops
+        #     never actually injected auto-notes here — confirmed by the
+        #     production v3.5 body, which has accumulated SHA sections
+        #     since 2023 and contains zero auto-gen markers. We must do
+        #     the same: read existing body, append new SHA summary, write.
+        #   - On CREATE: softprops + GitHub semantics for `body` plus
+        #     `generate_release_notes: true` PRE-pends the body to the
+        #     auto-generated notes (per action.yml docs and the
+        #     POST /releases REST API contract). `gh release create`
+        #     makes --generate-notes and --notes-file mutually exclusive,
+        #     so we fetch the generated body via the REST API and
+        #     concatenate in the correct order: BODY + "\n\n" + auto-notes.
+        # Asset overwrite via `--clobber` mirrors softprops's default
+        # `overwrite_files: true`. Title and draft state on update are
+        # left untouched, matching softprops's update path.
         run: |
           set -e
-
-          # Build release notes: auto-generated notes (mirrors softprops's
-          # `generate_release_notes: true`) followed by our SHA summary
-          # (mirrors `append_body: true`). `gh release create` makes
-          # --generate-notes and --notes-file mutually exclusive, so we
-          # fetch the generated body via the REST API and concatenate.
           NOTES_FILE="$RUNNER_TEMP/release-notes.md"
-          gh api -X POST "/repos/$GITHUB_REPOSITORY/releases/generate-notes" \
-            -f tag_name="$TAG" --jq '.body' > "$NOTES_FILE"
-          printf '\n\n%s\n' "$BODY" >> "$NOTES_FILE"
 
-          # Idempotent on tag: edit-and-upload if release exists, else create.
           if gh release view "$TAG" --json tagName >/dev/null 2>&1; then
+            # UPDATE path — preserve existing body, append SHA summary.
+            gh release view "$TAG" --json body --jq .body > "$NOTES_FILE"
+            printf '\n%s\n' "$BODY" >> "$NOTES_FILE"
             gh release edit   "$TAG" --notes-file "$NOTES_FILE"
             gh release upload "$TAG" artifact-shas/* artifact-binaries/* --clobber
           else
+            # CREATE path — body PRE-pended to auto-generated notes.
+            AUTO_NOTES="$RUNNER_TEMP/auto-notes.md"
+            gh api -X POST "/repos/$GITHUB_REPOSITORY/releases/generate-notes" \
+              -f tag_name="$TAG" --jq '.body' > "$AUTO_NOTES"
+            { printf '%s\n\n' "$BODY"; cat "$AUTO_NOTES"; } > "$NOTES_FILE"
+
             DRAFT_ARGS=()
             [ "$DRAFT" = "true" ] && DRAFT_ARGS=(--draft)
             gh release create "$TAG" "${DRAFT_ARGS[@]}" \

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -125,57 +125,54 @@ jobs:
           TAG: ${{ env.use_release_tag }}
           DRAFT: ${{ env.create_draft }}
           BODY: ${{ env.sha_summary }}
-        # Replaces a SHA-pinned `softprops/action-gh-release@d4e8205` call
-        # (Dec 2022) that ran with `generate_release_notes: true` and
-        # `append_body: true`. The branches below mirror the three code
-        # paths in that pinned source (src/github.ts `release()`):
+        # Publishes the collected binaries to a GitHub release using the
+        # `gh` CLI. Three cases, in order:
         #
-        #  1. input_draft=true AND a release already exists for the tag
-        #     → softprops returns it as-is and only re-uploads assets;
-        #     it does NOT update the body. (Drafts can't be fetched by
-        #     tag, so softprops scans allReleases for that case.)
-        #     Mirrored as the first `if` branch.
+        #  1. DRAFT=true AND a release already exists for $TAG
+        #     → leave the release body untouched and only re-upload assets
+        #       (with --clobber, so existing assets of the same name are
+        #       replaced). This avoids double-appending the SHA summary
+        #       on a re-run that targets the same draft tag.
         #
-        #  2. input_draft=false AND release exists → softprops updates
-        #     via PATCH /releases. With append_body=true, body becomes
-        #     `existingBody + "\n" + workflowBody`. `generate_release_notes`
-        #     is silently ignored by PATCH /releases (verified: the
-        #     production v3.5 body has no auto-gen markers despite 2.5
-        #     years of softprops updates). draft is forced to false.
-        #     name / target_commitish / prerelease are preserved.
-        #     Mirrored as the second `elif` branch.
+        #  2. DRAFT=false AND a release exists for $TAG (the rolling
+        #     release case, e.g. v3.5)
+        #     → append the new SHA summary to the existing release body
+        #       (single "\n" separator), publish if it was a draft
+        #       (--draft=false), then re-upload assets. `// ""` keeps a
+        #       null body field from being rendered as the literal "null".
+        #       Title, target commit and prerelease flag are left as-is.
         #
-        #  3. Release does not exist → softprops creates via POST
-        #     /releases. With body + generate_release_notes=true, the
-        #     GitHub REST contract pre-pends body to the auto-generated
-        #     notes. `gh release create` rejects --generate-notes with
-        #     --notes-file together, so we fetch generated notes via
-        #     POST /releases/generate-notes and concatenate in the
-        #     correct order: BODY + "\n\n" + auto-notes.
-        #     Mirrored as the final `else` branch.
+        #  3. No release exists for $TAG
+        #     → create a new release. Auto-generated notes are fetched
+        #       from POST /repos/.../releases/generate-notes and the SHA
+        #       summary is pre-pended (BODY + "\n\n" + auto-notes), since
+        #       `gh release create` does not allow --generate-notes and
+        #       --notes-file together. Created as a draft when DRAFT=true.
         #
-        # Asset upload uses `--clobber`, matching softprops's default
-        # `overwrite_files: true` (delete-then-upload by name).
+        # The release URL is exposed as the step output `url` for the
+        # following "Add release url to summary" step.
         run: |
           set -e
           NOTES_FILE="$RUNNER_TEMP/release-notes.md"
 
-          if [ "$DRAFT" = "true" ] && gh release view "$TAG" --json tagName >/dev/null 2>&1; then
-            # Path 1: draft re-run on the same tag — body untouched, assets refreshed.
+          RELEASE_EXISTS=false
+          if gh release view "$TAG" --json tagName >/dev/null 2>&1; then
+            RELEASE_EXISTS=true
+          fi
+
+          if [ "$DRAFT" = "true" ] && [ "$RELEASE_EXISTS" = "true" ]; then
+            # Case 1.
             gh release upload "$TAG" artifact-shas/* artifact-binaries/* --clobber
 
-          elif gh release view "$TAG" --json tagName >/dev/null 2>&1; then
-            # Path 2: update existing release. Append SHA summary to existing
-            # body using a single "\n" separator (matches softprops byte-for-byte).
-            # `// ""` defends against a null body field. `--draft=false` mirrors
-            # softprops's unconditional `draft: false` on this path.
+          elif [ "$RELEASE_EXISTS" = "true" ]; then
+            # Case 2.
             gh release view "$TAG" --json body --jq '.body // ""' > "$NOTES_FILE"
             printf '%s\n' "$BODY" >> "$NOTES_FILE"
             gh release edit   "$TAG" --notes-file "$NOTES_FILE" --draft=false
             gh release upload "$TAG" artifact-shas/* artifact-binaries/* --clobber
 
           else
-            # Path 3: create. Body pre-pended to auto-generated notes.
+            # Case 3.
             AUTO_NOTES="$RUNNER_TEMP/auto-notes.md"
             gh api -X POST "/repos/$GITHUB_REPOSITORY/releases/generate-notes" \
               -f tag_name="$TAG" --jq '.body' > "$AUTO_NOTES"

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -31,9 +31,9 @@ jobs:
     steps:
       - run: echo Is making new release? '${{ inputs.newRelease }}'
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: downloaded-artifacts
 
@@ -120,17 +120,39 @@ jobs:
 
       - name: Add binaries to release
         id: create_release
-        uses: softprops/action-gh-release@d4e8205d7e959a9107da6396278b2f1f07af0f9b
-        with:
-          token: ${{ github.token }}
-          draft: ${{ env.create_draft }}
-          tag_name: ${{ env.use_release_tag }}
-          files: |
-            artifact-shas/*
-            artifact-binaries/*
-          body: "${{ env.sha_summary }}"
-          generate_release_notes: true
-          append_body: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ env.use_release_tag }}
+          DRAFT: ${{ env.create_draft }}
+          BODY: ${{ env.sha_summary }}
+        run: |
+          set -e
+
+          # Build release notes: auto-generated notes (mirrors softprops's
+          # `generate_release_notes: true`) followed by our SHA summary
+          # (mirrors `append_body: true`). `gh release create` makes
+          # --generate-notes and --notes-file mutually exclusive, so we
+          # fetch the generated body via the REST API and concatenate.
+          NOTES_FILE="$RUNNER_TEMP/release-notes.md"
+          gh api -X POST "/repos/$GITHUB_REPOSITORY/releases/generate-notes" \
+            -f tag_name="$TAG" --jq '.body' > "$NOTES_FILE"
+          printf '\n\n%s\n' "$BODY" >> "$NOTES_FILE"
+
+          # Idempotent on tag: edit-and-upload if release exists, else create.
+          if gh release view "$TAG" --json tagName >/dev/null 2>&1; then
+            gh release edit   "$TAG" --notes-file "$NOTES_FILE"
+            gh release upload "$TAG" artifact-shas/* artifact-binaries/* --clobber
+          else
+            DRAFT_ARGS=()
+            [ "$DRAFT" = "true" ] && DRAFT_ARGS=(--draft)
+            gh release create "$TAG" "${DRAFT_ARGS[@]}" \
+              --title "$TAG" \
+              --notes-file "$NOTES_FILE" \
+              artifact-shas/* artifact-binaries/*
+          fi
+
+          URL=$(gh release view "$TAG" --json url --jq .url)
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
 
       - name: Add release url to summary
         run: echo "Release created/updated at ${{ steps.create_release.outputs.url }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -153,6 +153,12 @@ jobs:
         # following "Add release url to summary" step.
         run: |
           set -e
+
+          if [ -z "$TAG" ]; then
+            echo "::error::No release tag resolved: use_release_tag is empty. This happens when 'newRelease' is false and no previous release exists. Re-run with newRelease=true to create the first draft." >&2
+            exit 1
+          fi
+
           NOTES_FILE="$RUNNER_TEMP/release-notes.md"
 
           RELEASE_EXISTS=false
@@ -173,9 +179,15 @@ jobs:
 
           else
             # Case 3.
+            # Anchor the auto-generated notes to the commit being released
+            # (GITHUB_SHA) instead of the default branch HEAD, so dispatches
+            # from non-default branches still produce notes that reflect the
+            # built code. previous_tag_name is left to GitHub's heuristic.
             AUTO_NOTES="$RUNNER_TEMP/auto-notes.md"
             gh api -X POST "/repos/$GITHUB_REPOSITORY/releases/generate-notes" \
-              -f tag_name="$TAG" --jq '.body' > "$AUTO_NOTES"
+              -f tag_name="$TAG" \
+              -f target_commitish="$GITHUB_SHA" \
+              --jq '.body' > "$AUTO_NOTES"
             { printf '%s\n\n' "$BODY"; cat "$AUTO_NOTES"; } > "$NOTES_FILE"
 
             DRAFT_ARGS=()

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -126,38 +126,56 @@ jobs:
           DRAFT: ${{ env.create_draft }}
           BODY: ${{ env.sha_summary }}
         # Replaces a SHA-pinned `softprops/action-gh-release@d4e8205` call
-        # that ran with `generate_release_notes: true` + `append_body: true`.
-        # We must preserve those semantics exactly:
-        #   - On UPDATE (release already exists for the tag): softprops with
-        #     `append_body: true` keeps the existing release body and appends
-        #     the new `body`. `generate_release_notes` is silently ignored
-        #     by the GitHub PATCH /releases API on update, so softprops
-        #     never actually injected auto-notes here — confirmed by the
-        #     production v3.5 body, which has accumulated SHA sections
-        #     since 2023 and contains zero auto-gen markers. We must do
-        #     the same: read existing body, append new SHA summary, write.
-        #   - On CREATE: softprops + GitHub semantics for `body` plus
-        #     `generate_release_notes: true` PRE-pends the body to the
-        #     auto-generated notes (per action.yml docs and the
-        #     POST /releases REST API contract). `gh release create`
-        #     makes --generate-notes and --notes-file mutually exclusive,
-        #     so we fetch the generated body via the REST API and
-        #     concatenate in the correct order: BODY + "\n\n" + auto-notes.
-        # Asset overwrite via `--clobber` mirrors softprops's default
-        # `overwrite_files: true`. Title and draft state on update are
-        # left untouched, matching softprops's update path.
+        # (Dec 2022) that ran with `generate_release_notes: true` and
+        # `append_body: true`. The branches below mirror the three code
+        # paths in that pinned source (src/github.ts `release()`):
+        #
+        #  1. input_draft=true AND a release already exists for the tag
+        #     → softprops returns it as-is and only re-uploads assets;
+        #     it does NOT update the body. (Drafts can't be fetched by
+        #     tag, so softprops scans allReleases for that case.)
+        #     Mirrored as the first `if` branch.
+        #
+        #  2. input_draft=false AND release exists → softprops updates
+        #     via PATCH /releases. With append_body=true, body becomes
+        #     `existingBody + "\n" + workflowBody`. `generate_release_notes`
+        #     is silently ignored by PATCH /releases (verified: the
+        #     production v3.5 body has no auto-gen markers despite 2.5
+        #     years of softprops updates). draft is forced to false.
+        #     name / target_commitish / prerelease are preserved.
+        #     Mirrored as the second `elif` branch.
+        #
+        #  3. Release does not exist → softprops creates via POST
+        #     /releases. With body + generate_release_notes=true, the
+        #     GitHub REST contract pre-pends body to the auto-generated
+        #     notes. `gh release create` rejects --generate-notes with
+        #     --notes-file together, so we fetch generated notes via
+        #     POST /releases/generate-notes and concatenate in the
+        #     correct order: BODY + "\n\n" + auto-notes.
+        #     Mirrored as the final `else` branch.
+        #
+        # Asset upload uses `--clobber`, matching softprops's default
+        # `overwrite_files: true` (delete-then-upload by name).
         run: |
           set -e
           NOTES_FILE="$RUNNER_TEMP/release-notes.md"
 
-          if gh release view "$TAG" --json tagName >/dev/null 2>&1; then
-            # UPDATE path — preserve existing body, append SHA summary.
-            gh release view "$TAG" --json body --jq .body > "$NOTES_FILE"
-            printf '\n%s\n' "$BODY" >> "$NOTES_FILE"
-            gh release edit   "$TAG" --notes-file "$NOTES_FILE"
+          if [ "$DRAFT" = "true" ] && gh release view "$TAG" --json tagName >/dev/null 2>&1; then
+            # Path 1: draft re-run on the same tag — body untouched, assets refreshed.
             gh release upload "$TAG" artifact-shas/* artifact-binaries/* --clobber
+
+          elif gh release view "$TAG" --json tagName >/dev/null 2>&1; then
+            # Path 2: update existing release. Append SHA summary to existing
+            # body using a single "\n" separator (matches softprops byte-for-byte).
+            # `// ""` defends against a null body field. `--draft=false` mirrors
+            # softprops's unconditional `draft: false` on this path.
+            gh release view "$TAG" --json body --jq '.body // ""' > "$NOTES_FILE"
+            printf '%s\n' "$BODY" >> "$NOTES_FILE"
+            gh release edit   "$TAG" --notes-file "$NOTES_FILE" --draft=false
+            gh release upload "$TAG" artifact-shas/* artifact-binaries/* --clobber
+
           else
-            # CREATE path — body PRE-pended to auto-generated notes.
+            # Path 3: create. Body pre-pended to auto-generated notes.
             AUTO_NOTES="$RUNNER_TEMP/auto-notes.md"
             gh api -X POST "/repos/$GITHUB_REPOSITORY/releases/generate-notes" \
               -f tag_name="$TAG" --jq '.body' > "$AUTO_NOTES"

--- a/.github/workflows/build-alpine.yml
+++ b/.github/workflows/build-alpine.yml
@@ -14,13 +14,13 @@ jobs:
         target-node: [20, 22, 24]
         target-arch: [x64]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           build-args: |
             PKG_FETCH_OPTION_a=${{ matrix.target-arch }}
@@ -37,7 +37,7 @@ jobs:
           ls -l dist
           (test -f dist/*.sha256sum && echo "EXISTS=true" >> $GITHUB_OUTPUT) || echo "EXISTS=false" >> $GITHUB_OUTPUT
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: steps.check_file.outputs.EXISTS == 'true'
         with:
           name: node${{ matrix.target-node }}-alpine-${{ matrix.target-arch }}
@@ -53,13 +53,13 @@ jobs:
         target-arch: [arm64]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           build-args: |
             PKG_FETCH_OPTION_a=${{ matrix.target-arch }}
@@ -76,7 +76,7 @@ jobs:
           ls -l dist
           (test -f dist/*.sha256sum && echo "EXISTS=true" >> $GITHUB_OUTPUT) || echo "EXISTS=false" >> $GITHUB_OUTPUT
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: steps.check_file.outputs.EXISTS == 'true'
         with:
           name: node${{ matrix.target-node }}-alpine-${{ matrix.target-arch }}

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -22,14 +22,14 @@ jobs:
             platform: arm64
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build
         id: build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           build-args: |
             PKG_FETCH_OPTION_n=node${{ matrix.target-node }}
@@ -44,7 +44,7 @@ jobs:
           ls -l dist
           (test -f dist/*.sha256sum && echo "EXISTS=true" >> $GITHUB_OUTPUT) || echo "EXISTS=false" >> $GITHUB_OUTPUT
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: steps.check_file.outputs.EXISTS == 'true'
         with:
           name: node${{ matrix.target-node }}-linux-${{ matrix.arch.name }}

--- a/.github/workflows/build-linuxstatic.yml
+++ b/.github/workflows/build-linuxstatic.yml
@@ -25,13 +25,13 @@ jobs:
             host-arch: i686
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           build-args: |
             HOST_ARCH=${{ matrix.host-arch }}
@@ -50,7 +50,7 @@ jobs:
           ls -l dist
           (test -f dist/*.sha256sum && echo "EXISTS=true" >> $GITHUB_OUTPUT) || echo "EXISTS=false" >> $GITHUB_OUTPUT
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: steps.check_file.outputs.EXISTS == 'true'
         with:
           name: node${{ matrix.target-node }}-linuxstatic-${{ matrix.target-arch }}
@@ -66,13 +66,13 @@ jobs:
         target-arch: [x64]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           build-args: |
             PKG_FETCH_OPTION_a=${{ matrix.target-arch }}
@@ -88,7 +88,7 @@ jobs:
           ls -l dist
           (test -f dist/*.sha256sum && echo "EXISTS=true" >> $GITHUB_OUTPUT) || echo "EXISTS=false" >> $GITHUB_OUTPUT
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: steps.check_file.outputs.EXISTS == 'true'
         with:
           name: node${{ matrix.target-node }}-linuxstatic-${{ matrix.target-arch }}
@@ -104,13 +104,13 @@ jobs:
         target-arch: [arm64]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           build-args: |
             PKG_FETCH_OPTION_a=${{ matrix.target-arch }}
@@ -126,7 +126,7 @@ jobs:
           ls -l dist
           (test -f dist/*.sha256sum && echo "EXISTS=true" >> $GITHUB_OUTPUT) || echo "EXISTS=false" >> $GITHUB_OUTPUT
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: steps.check_file.outputs.EXISTS == 'true'
         with:
           name: node${{ matrix.target-node }}-linuxstatic-${{ matrix.target-arch }}

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -14,14 +14,14 @@ jobs:
         target-node: [20, 22, 24]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest
 
       - name: Use Node.js 20
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
 
@@ -51,7 +51,7 @@ jobs:
           ls -l dist
           (test -f dist/*.sha256sum && echo "EXISTS=true" >> $GITHUB_OUTPUT) || echo "EXISTS=false" >> $GITHUB_OUTPUT
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: steps.check_file.outputs.EXISTS == 'true'
         with:
           name: node${{ matrix.target-node }}-macos-x64
@@ -66,14 +66,14 @@ jobs:
         target-node: [20, 22, 24]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest
 
       - name: Use Node.js 20
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
 
@@ -109,7 +109,7 @@ jobs:
           ls -l dist
           (test -f dist/*.sha256sum && echo "EXISTS=true" >> $GITHUB_OUTPUT) || echo "EXISTS=false" >> $GITHUB_OUTPUT
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: steps.check_file.outputs.EXISTS == 'true'
         with:
           name: node${{ matrix.target-node }}-macos-arm64

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -20,15 +20,15 @@ jobs:
             os: windows-11-arm
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Use Node.js 20
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
           check-latest: true
@@ -49,7 +49,7 @@ jobs:
             "EXISTS=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
           }
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: steps.check_file.outputs.EXISTS == 'true'
         with:
           name: node${{ matrix.target-node }}-windows-${{ matrix.arch.name }}

--- a/.github/workflows/check-latest-node.yml
+++ b/.github/workflows/check-latest-node.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Compare versions
         id: compare

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'

--- a/.github/workflows/test-patch.yml
+++ b/.github/workflows/test-patch.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: "yarn"
@@ -42,7 +42,7 @@ jobs:
           yarn start --test --force-build --output ./output ${{ github.event.inputs.args }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           path: ./output/*
 

--- a/.github/workflows/update-expected.yml
+++ b/.github/workflows/update-expected.yml
@@ -27,10 +27,10 @@ jobs:
 
         runs-on: ${{ matrix.os }}
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
 
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                 node-version: ${{ matrix.node-version }}
                 cache: "yarn"
@@ -53,7 +53,7 @@ jobs:
                 yarn updateExpected
             
             - name: Create Pull Request
-              uses: peter-evans/create-pull-request@v4
+              uses: peter-evans/create-pull-request@v8
               with:
                 token: ${{ secrets.GITHUB_TOKEN }}
                 commit-message: "fix: update expected shas"


### PR DESCRIPTION
## Why

Every action across the workflows was several majors behind, and `softprops/action-gh-release` in `build-all.yml` was SHA-pinned to a commit from 2022-12-09 — SHA-pinning loses its security value when the pin is never refreshed (you get the security posture of v0.1 without the convenience of `@v3`).

## Changes

### Action major bumps

| Action | From | To |
|---|---|---|
| `actions/checkout` | v4 | v6 |
| `actions/setup-node` | v4 | v6 |
| `actions/setup-python` | v5 | v6 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/download-artifact` | v4 | v8 |
| `docker/setup-buildx-action` | v3 | v4 |
| `docker/build-push-action` | v5 | v7 |
| `peter-evans/create-pull-request` | v4 | v8 *(in `update-expected.yml`; `patch-node.yml` was already on v8)* |

Already current and untouched: `actions/ai-inference@v2`, `maxim-lobanov/setup-xcode@v1`.

### Breaking-change audit

Every major version's changelog was reviewed against actual workflow usage — no code changes are required:

- **`setup-node` v6** restricts *automatic* caching to npm only. We use **explicit** `cache: 'yarn'` everywhere, which is still fully supported.
- **`download-artifact` v8** removed automatic decompression and now uses `Content-Type`. `upload-artifact` always emits `application/zip`, so behaviour is preserved.
- **`download-artifact` v8** turns hash mismatches into errors (feature, not breakage).
- **`docker/setup-buildx-action` v4** removed the deprecated `config`, `config-inline`, `install` inputs. We call the action with **zero inputs** in all 6 places.
- **`docker/build-push-action` v7** removed the deprecated `DOCKER_BUILD_NO_SUMMARY` and `DOCKER_BUILD_EXPORT_RETENTION_DAYS` env vars. Neither is set anywhere in this repo.
- **`peter-evans/create-pull-request` v7** renamed `git-token` → `branch-token`. We don't set `git-token`; we only pass `token`, `commit-message`, `title`, `body`, `branch`, `base`, `delete-branch`, `labels`, `draft` — all unchanged across v4→v8.
- **`upload-artifact` v7** added an optional `archive` input; defaults are unchanged.

### `softprops/action-gh-release` → `gh release` CLI

Replaced the SHA-pinned action with an inline block using the `gh` CLI (first-party, pre-installed on every runner, no third-party trust, no SHA-pin maintenance going forward).

Behaviour preserved (matches the SHA-pinned softprops `release()` semantics, verified against its source):

- **Existing release, not a draft re-run** → append the SHA summary to the existing release body (`existingBody + "\n" + workflowBody`, mirroring `append_body: true`) and re-upload assets with `--clobber`. This preserves the rolling history that has been accumulated on the `v3.5` release body since 2023.
- **No release for the tag** → create the release with the SHA summary pre-pended to GitHub's auto-generated notes (mirroring `body` + `generate_release_notes: true`, where the GitHub REST contract pre-pends `body` to the auto-notes). `gh release create` rejects `--generate-notes` together with `--notes-file`, so notes are fetched via `POST /repos/.../releases/generate-notes` (anchored to `GITHUB_SHA`) and concatenated client-side in the correct order.
- **Draft tag already exists (re-run)** → leave the body untouched and only re-upload assets, mirroring softprops's early-return path for `input_draft=true` + tag found in `allReleases`.
- Idempotent on tag, same `outputs.url` consumed by the next step.
- Empty `TAG` is rejected up-front with a clear error message instead of letting `gh` fail later.

This removes the last third-party action from any release-publishing path in the repo.

## Out of scope

Two follow-ups deliberately not in this PR:

- The "PRs created by `peter-evans/create-pull-request` with the default `GITHUB_TOKEN` don't trigger CI" issue (root cause: GitHub suppresses workflow runs for events authored by the auto-injected token to prevent recursion). Affects `patch-node.yml` and `update-expected.yml`. Fix is to swap `secrets.GITHUB_TOKEN` for a user PAT — postponed at the maintainer's request.
- Bumping `peter-evans/create-pull-request@v4` was tracked above; the patch-node.yml usage was already at v8 from PR #165.

🤖 Generated with [Claude Code](https://claude.com/claude-code)