### PR TITLE
fix(ci): skip *.dockerbuild artifacts when collecting build outputs

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -36,6 +36,11 @@ jobs:
       - uses: actions/download-artifact@v8
         with:
           path: downloaded-artifacts
+          # Exclude the `*.dockerbuild` build-record artifacts that
+          # docker/build-push-action@v6+ uploads automatically. They
+          # contain no binaries/SHAs, so the artifact-folder steps below
+          # would fail on them ("mv: cannot stat '.../*.sha256sum'").
+          pattern: '!*.dockerbuild'
 
       - name: Get previous release tag
         env:


### PR DESCRIPTION
## Problem

The `Build All Latest Assets` workflow failed in the `collect-artifacts` job ([run 25868597144](https://github.com/yao-pkg/pkg-fetch/actions/runs/25868597144/job/76079158287)):

```
mv: cannot stat 'yao-pkg~pkg-fetch~2BGD7Y.dockerbuild/*.sha256sum': No such file or directory
##[error]Process completed with exit code 1.
```

## Root cause

A side effect of #169, which bumped `docker/build-push-action@v5 → @v7`.

`docker/build-push-action@v6+` automatically uploads a build-record artifact named `<owner>~<repo>~<random>.dockerbuild` for every docker build. The `collect-artifacts` job downloads *all* workflow artifacts (`actions/download-artifact` with no `name`/`pattern`), so those `.dockerbuild` directories landed in `downloaded-artifacts/` alongside the real `node*` build artifacts. The `Copy current workflow artifacts` loop then ran `mv $f/*.sha256sum` against a `.dockerbuild` directory — which contains no `.sha256sum` — and `set -e` failed the step.

The `docker/build-push-action` README documents this exact failure mode and the fix.

## Fix

Exclude the build records via `download-artifact`'s `pattern` input:

```yaml
- uses: actions/download-artifact@v8
  with:
    path: downloaded-artifacts
    pattern: '!*.dockerbuild'
```

`download-artifact@v8` filters with `new Minimatch(pattern)`, which honors the `!` negation — `node*` artifacts match, `*.dockerbuild` ones don't. The build records keep uploading (useful for debugging docker builds, importable to Docker Desktop); only this consumer skips them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)