### PR TITLE
fix(macos): build Node 26 on macos-15 and disable LTO

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -7,6 +7,13 @@ on:
 jobs:
   macos-x64:
     runs-on: macos-15-intel
+    env:
+      # ccache: rewrite absolute paths under the workspace to relative ones so
+      # cached objects stay valid across runs, and key the compiler by content.
+      CCACHE_BASEDIR: ${{ github.workspace }}
+      CCACHE_COMPILERCHECK: content
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+      CCACHE_MAXSIZE: 2G
 
     strategy:
       fail-fast: false
@@ -15,6 +22,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+
+      - name: Restore ccache
+        uses: actions/cache@v4
+        with:
+          path: .ccache
+          key: ccache-macos-x64-node${{ matrix.target-node }}-${{ hashFiles('patches/**', 'lib/build.ts', 'lib/apply-patches.ts', 'package.json', 'yarn.lock') }}
+          restore-keys: |
+            ccache-macos-x64-node${{ matrix.target-node }}-
+            ccache-macos-x64-
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:
@@ -32,6 +48,16 @@ jobs:
         run: |
           pip install setuptools
 
+      # ccache speeds up rebuilds; GNU make v4 fixes `make -j N`
+      # (https://github.com/nodejs/node/issues/53176#issuecomment-2134740862)
+      - name: Install build tools (ccache, GNU make)
+        run: brew install ccache make
+
+      - name: Put build tools first in PATH
+        run: |
+          echo "$(brew --prefix)/opt/make/libexec/gnubin" >> "$GITHUB_PATH"
+          echo "$(brew --prefix)/opt/ccache/libexec" >> "$GITHUB_PATH"
+
       # Remove unneeded stuff to free up build space (from Node https://github.com/nodejs/build/issues/3878)
       - name: Cleanup before build
         run: |
@@ -43,7 +69,18 @@ jobs:
 
       - run: yarn start --node-range node${{ matrix.target-node }} --arch x64 --output dist
         env:
+          # bare command names so they resolve to the ccache shims placed first in PATH
+          CC: clang
+          CXX: clang++
+          CC_host: clang
+          CXX_host: clang++
           MAKE_JOB_COUNT: 4 # prevent to run out of memory
+          # build under the workspace (= CCACHE_BASEDIR) so ccache paths stay stable across runs
+          PKG_BUILD_PATH: ${{ github.workspace }}/.pkg-build
+
+      - name: Show ccache stats
+        if: always()
+        run: ccache --show-stats || true
 
       - name: Check if binary is compiled, skip if download only
         id: check_file
@@ -58,7 +95,16 @@ jobs:
           path: dist/*
 
   macos-arm64:
-    runs-on: macos-14 # macos-14 is arm64: https://github.com/actions/runner-images#available-images
+    # macos-15 is arm64 and ships Xcode 16.4, whose libc++ provides std::atomic_ref
+    # (required by V8 in Node 26). macos-14's newest Xcode is 16.2 and fails to build.
+    runs-on: macos-15
+    env:
+      # ccache: rewrite absolute paths under the workspace to relative ones so
+      # cached objects stay valid across runs, and key the compiler by content.
+      CCACHE_BASEDIR: ${{ github.workspace }}
+      CCACHE_COMPILERCHECK: content
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+      CCACHE_MAXSIZE: 2G
 
     strategy:
       fail-fast: false
@@ -67,6 +113,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+
+      - name: Restore ccache
+        uses: actions/cache@v4
+        with:
+          path: .ccache
+          key: ccache-macos-arm64-node${{ matrix.target-node }}-${{ hashFiles('patches/**', 'lib/build.ts', 'lib/apply-patches.ts', 'package.json', 'yarn.lock') }}
+          restore-keys: |
+            ccache-macos-arm64-node${{ matrix.target-node }}-
+            ccache-macos-arm64-
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:
@@ -86,9 +141,15 @@ jobs:
 
       - run: yarn install --ignore-engines
 
-      # add missing distutils package to python 3.12
-      - name: Install distutils
-        run: brew install python-setuptools
+      # add missing distutils package to python 3.12, plus ccache and GNU make v4
+      # (GNU make v4 fixes `make -j N`: https://github.com/nodejs/node/issues/53176#issuecomment-2134740862)
+      - name: Install build tools
+        run: brew install python-setuptools ccache make
+
+      - name: Put build tools first in PATH
+        run: |
+          echo "$(brew --prefix)/opt/make/libexec/gnubin" >> "$GITHUB_PATH"
+          echo "$(brew --prefix)/opt/ccache/libexec" >> "$GITHUB_PATH"
 
       # Remove unneeded stuff to free up build space (from Node https://github.com/nodejs/build/issues/3878)
       - name: Cleanup before build
@@ -101,7 +162,18 @@ jobs:
 
       - run: yarn start --node-range node${{ matrix.target-node }} --arch arm64 --output dist
         env:
+          # bare command names so they resolve to the ccache shims placed first in PATH
+          CC: clang
+          CXX: clang++
+          CC_host: clang
+          CXX_host: clang++
           MAKE_JOB_COUNT: 2 # prevent to run out of memory
+          # build under the workspace (= CCACHE_BASEDIR) so ccache paths stay stable across runs
+          PKG_BUILD_PATH: ${{ github.workspace }}/.pkg-build
+
+      - name: Show ccache stats
+        if: always()
+        run: ccache --show-stats || true
 
       - name: Check if binary is compiled
         id: check_file

--- a/lib/build.ts
+++ b/lib/build.ts
@@ -50,8 +50,11 @@ function getConfigureArgs(major: number, targetPlatform: string, targetArch: str
   }
 
   // Link Time Optimization
+  // Skipped on macOS: LTO makes the link phase enormously slow and pushes the
+  // build past GitHub Actions' 6h job limit (worst on the Intel x64 runner).
+  // See yao-pkg/pkg-fetch#170.
   if (major >= 12) {
-    if (hostPlatform !== 'win') {
+    if (hostPlatform !== 'win' && targetPlatform !== 'macos') {
       args.push('--enable-lto');
     }
   }


### PR DESCRIPTION
## Problem

The macOS Node 26 builds fail in `build-all.yml`:

- **`macos-arm64 (26)`** fails fast in the compile step:
  ```
  ../deps/v8/src/base/atomicops.h:90: error: no member named 'atomic_ref' in namespace 'std'
  ```
  `std::atomic_ref` is a C++20 library feature that V8 in Node 26 now uses in `atomicops.h`. The job was pinned to `runs-on: macos-14`, whose newest available Xcode is **16.2** — its libc++ predates `std::atomic_ref`. Xcode 16.3+ (requires macOS 15) ships the libc++ that has it. Confirmed empirically: the `macos-15-intel` x64 job compiles straight past `atomicops.h`.

- **`macos-x64 (24)` and `(26)`** hit GitHub Actions' **6h job limit**. `getConfigureArgs` force-enabled `--enable-lto` for every non-Windows build, and the LTO link phase is enormously slow on the Intel runner.

Both are the macOS issues described in #170.

## Changes

- **`build-macos.yml`** — bump the arm64 runner `macos-14` → `macos-15` (Xcode 16.4 → libc++ with `std::atomic_ref`).
- **`lib/build.ts`** — skip `--enable-lto` for macOS in `getConfigureArgs` (Windows was already excluded).
- **`build-macos.yml`** — add ccache (`actions/cache` + `PKG_BUILD_PATH` under `CCACHE_BASEDIR`) and GNU make v4 to both macOS jobs, so rebuilds stay fast and `make -j` works correctly.

## Notes

- `PKG_BUILD_PATH` is already supported upstream (`build.ts:18`); pointing it under the workspace keeps ccache paths stable across runs.
- The first run after this lands has no warm cache, so it relies on the LTO removal alone to fit within 6h; subsequent runs benefit from ccache.
- Action versions (`checkout@v6`, `setup-node@v6`, `upload-artifact@v7`) and the `[22, 24, 26]` matrix are unchanged.

Refs #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)