### PR TITLE
chore(release): land 3.6.2 (bump + changelog)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [3.6.2](https://github.com/yao-pkg/pkg-fetch/compare/v3.6...v3.6.2) (2026-05-26)
+
+### Bug Fixes
+
+- update expected shas ([#178](https://github.com/yao-pkg/pkg-fetch/issues/178)) ([9aa7a54](https://github.com/yao-pkg/pkg-fetch/commit/9aa7a5474f7f1af87e3ad0d6b0c4f99dad2967d6))
+
 ## [3.5.33](https://github.com/yao-pkg/pkg-fetch/compare/v3.5.32...v3.5.33) (2026-03-31)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yao-pkg/pkg-fetch",
-  "version": "3.5.33",
+  "version": "3.6.2",
   "description": "Compiles and stores base binaries for pkg",
   "main": "lib-es5/index.js",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Reconciles `main` with the already-published `@yao-pkg/pkg-fetch@3.6.2` (npm) and the existing `v3.6.2` git tag. The `Release-it` workflow (run [`26458510953`](https://github.com/yao-pkg/pkg-fetch/actions/runs/26458510953)) successfully published to npm and pushed the tag, but its commit was rejected by branch protection (`GH006: 3 of 3 required status checks are expected`) — release-it can't push a commit straight to a protected branch, and the auto-rollback can't undo an npm publish or a remote tag push.

This PR carries the exact commit that was rejected (`7fb8b25 Release 3.6.2`, which `v3.6.2` already points to) through the PR flow so CI checks gate it, then lands it. After merge, main matches the published artifact.

### What's in the commit

- `package.json`: `3.5.33` → `3.6.2`
- `CHANGELOG.md`: prepend 3.6.2 entry (only relevant change since 3.5.33 is the merged update-expected-shas PR #178)

### Why 3.6.2 and not 3.6.0 / 3.6.1

- `3.6.0` on npm is from 2023-12-05, deprecated as `"published by error"` — too old to `npm unpublish` (72h window).
- `3.6.1` was published earlier today (also bypassing the proper flow) — same orphan state, never landed on main.

3.6.2 supersedes both and is the first version cleanly tied to a tag pointing at real content.

### Related

Context: build-all workflow run [`26274852835`](https://github.com/yao-pkg/pkg-fetch/actions/runs/26274852835) was failing with `file_count limited to 1000 assets per release` (v3.5 release at 997/1000). Fix: created fresh `v3.6` release as the new binary target; v3.5 preserved unchanged for legacy 3.5.x consumers (`tagFromVersion` in `lib/places.ts`).

## Test plan

- [ ] CI tests (20, 22, 24) pass against this branch.
- [ ] After merge: verify `git log origin/main` shows `7fb8b25`, and that `git describe --tags --exact-match origin/main` doesn't apply (tag remains on its current commit, which is already this one).