### PR TITLE
fix: prevent silent exit on premature download close

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,11 +1,11 @@
-import fetch from 'node-fetch';
+import { fetch, ProxyAgent } from 'undici';
 import crypto from 'crypto';
 import { createReadStream, createWriteStream, mkdirSync, renameSync, rmSync } from 'fs';
 import { chmod, stat } from 'fs/promises';
-import httpsProxyAgent from 'https-proxy-agent';
 import path from 'path';
+import { Readable } from 'stream';
+import { pipeline } from 'stream/promises';
 import { spawnSync, SpawnSyncOptions } from 'child_process';
-import stream from 'stream';
 
 import { coerce } from 'semver';
 import { log, wasReported } from './log';
@@ -24,14 +24,14 @@ export async function downloadUrl(url: string, file: string): Promise<void> {
   try {
     res = await fetch(
       url,
-      proxy ? { agent: httpsProxyAgent(proxy) } : undefined
+      proxy ? { dispatcher: new ProxyAgent(proxy) } : undefined
     );
   } catch (err) {
     log.disableProgress();
     throw wasReported(`Network error during fetch: ${(err as Error).message}`);
   }
 
-  if (!res.ok) {
+  if (!res.ok || !res.body) {
     log.disableProgress();
     throw wasReported(`${res.status}: ${res.statusText}`);
   }
@@ -43,28 +43,28 @@ export async function downloadUrl(url: string, file: string): Promise<void> {
   const totalSize = Number(res.headers.get('content-length'));
   let currentSize = 0;
 
-  res.body.on('data', (chunk: Buffer) => {
+  const body = Readable.fromWeb(res.body);
+  body.on('data', (chunk: Buffer) => {
     if (totalSize != null && totalSize !== 0) {
       currentSize += chunk.length;
       log.showProgress((currentSize / totalSize) * 100);
     }
   });
-  res.body.pipe(ws);
 
-  return new Promise<void>((resolve, reject) => {
-    stream.finished(ws, (err) => {
-      if (err) {
-        log.disableProgress();
-        rmSync(tempFile);
-        reject(wasReported(`${err.name}: ${err.message}`));
-      } else {
-        log.showProgress(100);
-        log.disableProgress();
-        renameSync(tempFile, file);
-        resolve();
-      }
-    });
-  });
+  // `pipeline` propagates errors from the source (`body`) as well as the
+  // destination (`ws`), so a truncated/aborted download rejects loudly instead
+  // of leaving the promise unsettled and the process exiting silently.
+  try {
+    await pipeline(body, ws);
+  } catch (err) {
+    log.disableProgress();
+    rmSync(tempFile, { force: true });
+    throw wasReported(`${(err as Error).name}: ${(err as Error).message}`);
+  }
+
+  log.showProgress(100);
+  log.disableProgress();
+  renameSync(tempFile, file);
 }
 
 export async function hash(filePath: string): Promise<string> {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -20,51 +20,66 @@ export async function downloadUrl(url: string, file: string): Promise<void> {
     process.env.HTTP_PROXY ??
     process.env.http_proxy;
 
-  let res;
+  // Created once and closed in `finally` so its connection pool never leaks,
+  // even across the multiple throw paths below.
+  const dispatcher = proxy ? new ProxyAgent(proxy) : undefined;
+
   try {
-    res = await fetch(
-      url,
-      proxy ? { dispatcher: new ProxyAgent(proxy) } : undefined
-    );
-  } catch (err) {
-    log.disableProgress();
-    throw wasReported(`Network error during fetch: ${(err as Error).message}`);
-  }
-
-  if (!res.ok || !res.body) {
-    log.disableProgress();
-    throw wasReported(`${res.status}: ${res.statusText}`);
-  }
-
-  const tempFile = `${file}.downloading`;
-  mkdirSync(path.dirname(tempFile), { recursive: true });
-  const ws = createWriteStream(tempFile);
-
-  const totalSize = Number(res.headers.get('content-length'));
-  let currentSize = 0;
-
-  const body = Readable.fromWeb(res.body);
-  body.on('data', (chunk: Buffer) => {
-    if (totalSize != null && totalSize !== 0) {
-      currentSize += chunk.length;
-      log.showProgress((currentSize / totalSize) * 100);
+    let res;
+    try {
+      res = await fetch(url, dispatcher ? { dispatcher } : undefined);
+    } catch (err) {
+      log.disableProgress();
+      throw wasReported(
+        `Network error during fetch: ${(err as Error).message}`
+      );
     }
-  });
 
-  // `pipeline` propagates errors from the source (`body`) as well as the
-  // destination (`ws`), so a truncated/aborted download rejects loudly instead
-  // of leaving the promise unsettled and the process exiting silently.
-  try {
-    await pipeline(body, ws);
-  } catch (err) {
+    if (!res.ok) {
+      log.disableProgress();
+      throw wasReported(`${res.status}: ${res.statusText}`);
+    }
+
+    if (!res.body) {
+      log.disableProgress();
+      throw wasReported(`Empty response body for ${url}`);
+    }
+
+    const tempFile = `${file}.downloading`;
+    mkdirSync(path.dirname(tempFile), { recursive: true });
+    const ws = createWriteStream(tempFile);
+
+    const totalSize = Number(res.headers.get('content-length'));
+    let currentSize = 0;
+
+    const body = Readable.fromWeb(res.body);
+    body.on('data', (chunk: Buffer) => {
+      // Falsy for both a missing header (`NaN`) and a zero length, avoiding a
+      // `NaN%` progress reading.
+      if (totalSize) {
+        currentSize += chunk.length;
+        log.showProgress((currentSize / totalSize) * 100);
+      }
+    });
+
+    // `pipeline` propagates errors from the source (`body`) as well as the
+    // destination (`ws`), so a truncated/aborted download rejects loudly
+    // instead of leaving the promise unsettled and the process exiting
+    // silently.
+    try {
+      await pipeline(body, ws);
+    } catch (err) {
+      log.disableProgress();
+      rmSync(tempFile, { force: true });
+      throw wasReported(`${(err as Error).name}: ${(err as Error).message}`);
+    }
+
+    log.showProgress(100);
     log.disableProgress();
-    rmSync(tempFile, { force: true });
-    throw wasReported(`${(err as Error).name}: ${(err as Error).message}`);
+    renameSync(tempFile, file);
+  } finally {
+    await dispatcher?.close();
   }
-
-  log.showProgress(100);
-  log.disableProgress();
-  renameSync(tempFile, file);
 }
 
 export async function hash(filePath: string): Promise<string> {

--- a/package.json
+++ b/package.json
@@ -18,18 +18,16 @@
     "patches/*"
   ],
   "dependencies": {
-    "https-proxy-agent": "^5.0.0",
-    "node-fetch": "^2.6.6",
     "picocolors": "^1.1.0",
     "progress": "^2.0.3",
     "semver": "^7.3.5",
     "tar-fs": "^3.1.1",
+    "undici": "^7.28.0",
     "yargs": "^16.2.0"
   },
   "devDependencies": {
     "@release-it/conventional-changelog": "^7.0.2",
-    "@types/node": "^16.18.113",
-    "@types/node-fetch": "^2.5.12",
+    "@types/node": "^20.19.43",
     "@types/progress": "^2.0.5",
     "@types/semver": "^7.3.9",
     "@types/tar-fs": "^2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -287,23 +287,17 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
-"@types/node-fetch@^2.5.12":
-  version "2.6.6"
-  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.6.tgz#b72f3f4bc0c0afee1c0bc9cff68e041d01e3e779"
-  integrity sha512-95X8guJYhfqiuVVhRFxVQcf4hW/2bCuoPwDasMf/531STFoNoWTT7YDnWdXHEZKqAGUigmpG31r2FE70LwnzJw==
-  dependencies:
-    "@types/node" "*"
-    form-data "^4.0.0"
-
 "@types/node@*":
   version "20.8.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.8.2.tgz#d76fb80d87d0d8abfe334fc6d292e83e5524efc4"
   integrity sha512-Vvycsc9FQdwhxE3y3DzeIxuEJbWGDsnrxvMADzTDF/lcdR9/K+AQIeAghTQsHtotg/q0j3WEOYS/jQgSdWue3w==
 
-"@types/node@^16.18.113":
-  version "16.18.113"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.113.tgz#fbe99013933c4997db5838d20497494a7e01f4ab"
-  integrity sha512-4jHxcEzSXpF1cBNxogs5FVbVSFSKo50sFCn7Xg7vmjJTbWFWgeuHW3QnoINlfmfG++MFR/q97RZE5RQXKeT+jg==
+"@types/node@^20.19.43":
+  version "20.19.43"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.19.43.tgz#fcecf580ba42a0db55cf404c372c97973c376c97"
+  integrity sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==
+  dependencies:
+    undici-types "~6.21.0"
 
 "@types/normalize-package-data@^2.4.1":
   version "2.4.2"
@@ -446,13 +440,6 @@ add-stream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/add-stream/-/add-stream-1.0.0.tgz#6a7990437ca736d5e1288db92bd3266d5f5cb2aa"
   integrity sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==
-
-agent-base@6:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
-  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
-  dependencies:
-    debug "4"
 
 agent-base@^7.0.2, agent-base@^7.1.0:
   version "7.1.0"
@@ -651,11 +638,6 @@ async-retry@1.3.3:
   integrity sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==
   dependencies:
     retry "0.13.1"
-
-asynckit@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
-  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
 available-typed-arrays@^1.0.5:
   version "1.0.5"
@@ -975,13 +957,6 @@ colorette@^2.0.16:
   version "2.0.20"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.20.tgz#9eb793e6833067f7235902fcd3b09917a000a95a"
   integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
-
-combined-stream@^1.0.8:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
-  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
-  dependencies:
-    delayed-stream "~1.0.0"
 
 commander@^6.2.0:
   version "6.2.1"
@@ -1313,11 +1288,6 @@ degenerator@^5.0.0:
     ast-types "^0.13.4"
     escodegen "^2.1.0"
     esprima "^4.0.1"
-
-delayed-stream@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
-  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 deprecation@^2.0.0:
   version "2.3.1"
@@ -1883,15 +1853,6 @@ form-data-encoder@^2.1.2:
   resolved "https://registry.yarnpkg.com/form-data-encoder/-/form-data-encoder-2.1.4.tgz#261ea35d2a70d48d30ec7a9603130fa5515e9cd5"
   integrity sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==
 
-form-data@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
-  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.8"
-    mime-types "^2.1.12"
-
 formdata-polyfill@^4.0.10:
   version "4.0.10"
   resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz#24807c31c9d402e002ab3d8c720144ceb8848423"
@@ -2242,14 +2203,6 @@ http2-wrapper@^2.1.10:
   dependencies:
     quick-lru "^5.1.1"
     resolve-alpn "^1.2.0"
-
-https-proxy-agent@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
-  integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
-  dependencies:
-    agent-base "6"
-    debug "4"
 
 https-proxy-agent@^7.0.2:
   version "7.0.2"
@@ -2968,7 +2921,7 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@2.1.35, mime-types@^2.1.12:
+mime-types@2.1.35:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -3070,7 +3023,7 @@ node-fetch@3.3.2:
     fetch-blob "^3.1.4"
     formdata-polyfill "^4.0.10"
 
-node-fetch@^2.6.6, node-fetch@^2.6.7:
+node-fetch@^2.6.7:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
@@ -4296,6 +4249,16 @@ unbox-primitive@^1.0.2:
     has-bigints "^1.0.2"
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
+
+undici-types@~6.21.0:
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
+  integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
+
+undici@^7.28.0:
+  version "7.28.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-7.28.0.tgz#97d64564198b285bc281f0e8e29597e3d11fe7ec"
+  integrity sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==
 
 unique-string@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
## Problem

Downloads that get truncated or aborted mid-stream (e.g. a dropped connection during a Docker build) could cause `pkg-fetch` to **exit silently with an incomplete file** instead of failing loudly.

The old `downloadUrl` piped `res.body` (from `node-fetch`) into the write stream and only watched the **destination** via `stream.finished(ws, ...)`. A premature close errors on the **source**, which never propagated to the destination's `finished` callback — so the promise settled as success and a partial/corrupt asset was left behind.

## Fix

Stream the response body through `stream/promises` `pipeline(body, ws)`, which propagates errors from **both** source and destination. A premature close now rejects loudly and the partial `.downloading` tempfile is cleaned up.

While here, migrate from `node-fetch` + `https-proxy-agent` to **undici**:

- `undici` is what Node's native `fetch` is built on (maintained by the Node team).
- Net **fewer** dependencies: removes `node-fetch`, `https-proxy-agent`, and `@types/node-fetch`; adds one runtime dep (`undici`, self-typed).
- `ProxyAgent` preserves existing `HTTPS_PROXY`/`HTTP_PROXY` support — native `fetch` cannot proxy on its own, so undici is required regardless.
- `@types/node` bumped to `^20` for `Readable.fromWeb`.

## Verification

- `yarn build` ✅ &nbsp; `yarn lint` ✅
- Functional test against a local HTTP server (no Node build):
  - **Full download** → correct SHA-256, tempfile cleaned. ✅
  - **Truncated download** (Content-Length claims full size, socket destroyed mid-stream) → now **rejects** (`TypeError: terminated`) and removes the `.downloading` tempfile, instead of silently resolving. ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)